### PR TITLE
添加 --static 参数，强制使用静态IP

### DIFF
--- a/initrd-network.sh
+++ b/initrd-network.sh
@@ -8,6 +8,7 @@ ipv4_gateway=$3
 ipv6_addr=$4
 ipv6_gateway=$5
 is_in_china=$6
+force_static=$7
 
 DHCP_TIMEOUT=15
 DNS_FILE_TIMEOUT=5
@@ -444,6 +445,7 @@ mkdir -p "$netconf"
 $dhcpv4 && echo 1 >"$netconf/dhcpv4" || echo 0 >"$netconf/dhcpv4"
 $should_disable_ra_slaac && echo 1 >"$netconf/should_disable_ra_slaac" || echo 0 >"$netconf/should_disable_ra_slaac"
 $is_in_china && echo 1 >"$netconf/is_in_china" || echo 0 >"$netconf/is_in_china"
+$force_static && echo 1 >"$netconf/force_static" || echo 0 >"$netconf/force_static"
 echo "$ethx" >"$netconf/ethx"
 echo "$mac_addr" >"$netconf/mac_addr"
 echo "$ipv4_addr" >"$netconf/ipv4_addr"

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -3224,16 +3224,17 @@ EOF
 get_ip_conf_cmd() {
     collect_netconf >&2
     is_in_china && is_in_china=true || is_in_china=false
+    [ "$force_static" = 1 ] && force_static=true || force_static=false
 
     sh=/initrd-network.sh
     if is_found_ipv4_netconf && is_found_ipv6_netconf && [ "$ipv4_mac" = "$ipv6_mac" ]; then
-        echo "'$sh' '$ipv4_mac' '$ipv4_addr' '$ipv4_gateway' '$ipv6_addr' '$ipv6_gateway' '$is_in_china'"
+        echo "'$sh' '$ipv4_mac' '$ipv4_addr' '$ipv4_gateway' '$ipv6_addr' '$ipv6_gateway' '$is_in_china' '$force_static'"
     else
         if is_found_ipv4_netconf; then
-            echo "'$sh' '$ipv4_mac' '$ipv4_addr' '$ipv4_gateway' '' '' '$is_in_china'"
+            echo "'$sh' '$ipv4_mac' '$ipv4_addr' '$ipv4_gateway' '' '' '$is_in_china' '$force_static'"
         fi
         if is_found_ipv6_netconf; then
-            echo "'$sh' '$ipv6_mac' '' '' '$ipv6_addr' '$ipv6_gateway' '$is_in_china'"
+            echo "'$sh' '$ipv6_mac' '' '' '$ipv6_addr' '$ipv6_gateway' '$is_in_china' '$force_static'"
         fi
     fi
 }
@@ -3485,7 +3486,7 @@ else
 fi
 
 long_opts=
-for o in ci installer debug minimal allow-ping \
+for o in ci installer debug minimal allow-ping static \
     hold: sleep: \
     iso: \
     image-name: \
@@ -3537,6 +3538,10 @@ while true; do
         ;;
     --allow-ping)
         allow_ping=1
+        shift
+        ;;
+    --static)
+        force_static=1
         shift
         ;;
     --hold | --sleep)

--- a/trans.sh
+++ b/trans.sh
@@ -581,9 +581,16 @@ is_in_china() {
     grep -q 1 /dev/netconf/*/is_in_china
 }
 
+force_static() {
+    grep -q 1 /dev/netconf/*/force_static
+}
+
 # 有 dhcpv4 不等于有网关，例如 vultr 纯 ipv6
 # 没有 dhcpv4 不等于是静态ip，可能是没有 ip
 is_dhcpv4() {
+    if force_static; then
+        return 1
+    fi
     get_netconf_to dhcpv4
     # shellcheck disable=SC2154
     [ "$dhcpv4" = 1 ]
@@ -612,12 +619,18 @@ is_staticv6() {
 }
 
 should_disable_ra_slaac() {
+    if force_static; then
+        return 1
+    fi
     get_netconf_to should_disable_ra_slaac
     # shellcheck disable=SC2154
     [ "$should_disable_ra_slaac" = 1 ]
 }
 
 is_slaac() {
+    if force_static; then
+        return 1
+    fi
     # 防止部分机器slaac/dhcpv6获取的ip/网关无法上网
     if should_disable_ra_slaac; then
         return 1
@@ -628,6 +641,9 @@ is_slaac() {
 }
 
 is_dhcpv6() {
+    if force_static; then
+        return 1
+    fi
     # 防止部分机器slaac/dhcpv6获取的ip/网关无法上网
     if should_disable_ra_slaac; then
         return 1


### PR DESCRIPTION
部分商家使用的 [VirtFusion](https://virtfusion.com/) 可能在 DHCP/SLAAC 上存在某些反复横跳的问题，例如 [HaloCloud](https://my.halocloud.net/index.php?rp=/store/hongkong-hkbgp-standard-ipv6/hkbgp-standard-vps-ipv6-500gb) 这款IPv6 Only的HK。

在今年1月时，使用 "reinstall.sh debian" 这台机器可以正常进入Debian安装器并完成安装，但进入系统后，网卡的默认配置 “iface $ethx inet6 auto” 无法获取IP，但这种问题在Alpine中并不存在。

而到最近，使用 "reinstall.sh debian" 在Debian安装器中都无法下载debian.cfg，可能SLAAC中没有下发正确的DNS。

为了防止环境中存在不符合预期的 DHCP/SLAAC 配置，添加 --static 参数，安装后的网卡使用静态设置IP。但Debian安装器中还是会使用DHCP获取IP（不会改），所以推荐与 --ci 同时使用（Alpine的网络处理比较稳定）。

关于 https://github.com/bin456789/reinstall/pull/262#issuecomment-2636917926 所提到的国内使用security镜像站问题，我认为在安装阶段还是应该保证安装成功率（例如某些国内VPS禁止访问国外流量）；安装成功后，应该由用户配置为最佳的安全设置。