### PR TITLE
trans.sh: fix typo

### DIFF
--- a/trans.sh
+++ b/trans.sh
@@ -3693,7 +3693,7 @@ change_ssh_conf() {
 
 allow_password_login() {
     os_dir=$1
-    change_ssh_conf "$os_dir" PasswordAuthentication yes 01-PasswordAuthenticaton.conf
+    change_ssh_conf "$os_dir" PasswordAuthentication yes 01-PasswordAuthentication.conf
 }
 
 allow_root_password_login() {


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修正了 SSH 配置文件名中的一个拼写错误，从 '01-PasswordAuthenticaton.conf' 改为 '01-PasswordAuthentication.conf'

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected a misspelling in the SSH configuration filename from '01-PasswordAuthenticaton.conf' to '01-PasswordAuthentication.conf'

</details>