### PR TITLE
feat: implement secondary DNS fallback for connectivity tests

### DIFF
--- a/initrd-network.sh
+++ b/initrd-network.sh
@@ -240,11 +240,11 @@ test_connect() {
 test_internet() {
     for i in $(seq 5); do
         echo "Testing Internet Connection. Test $i... "
-        if is_need_test_ipv4 && { test_connect "$(get_first_ipv4_addr | remove_netmask)" "$ipv4_dns1" >/dev/null 2>&1 || test_connect "$(get_first_ipv4_addr | remove_netmask)" "$ipv4_dns2" >/dev/null 2>&1; }; then
+        if is_need_test_ipv4 && { local current_ipv4_addr; current_ipv4_addr="$(get_first_ipv4_addr | remove_netmask)"; test_connect "$current_ipv4_addr" "$ipv4_dns1" >/dev/null 2>&1 || test_connect "$current_ipv4_addr" "$ipv4_dns2" >/dev/null 2>&1; }; then
             echo "IPv4 has internet."
             ipv4_has_internet=true
         fi
-        if is_need_test_ipv6 && { test_connect "$(get_first_ipv6_addr | remove_netmask)" "$ipv6_dns1" >/dev/null 2>&1 || test_connect "$(get_first_ipv6_addr | remove_netmask)" "$ipv6_dns2" >/dev/null 2>&1; }; then
+        if is_need_test_ipv6 && { local current_ipv6_addr; current_ipv6_addr="$(get_first_ipv6_addr | remove_netmask)"; test_connect "$current_ipv6_addr" "$ipv6_dns1" >/dev/null 2>&1 || test_connect "$current_ipv6_addr" "$ipv6_dns2" >/dev/null 2>&1; }; then
             echo "IPv6 has internet."
             ipv6_has_internet=true
         fi

--- a/initrd-network.sh
+++ b/initrd-network.sh
@@ -240,11 +240,11 @@ test_connect() {
 test_internet() {
     for i in $(seq 5); do
         echo "Testing Internet Connection. Test $i... "
-        if is_need_test_ipv4 && test_connect "$(get_first_ipv4_addr | remove_netmask)" "$ipv4_dns1" >/dev/null 2>&1; then
+        if is_need_test_ipv4 && { test_connect "$(get_first_ipv4_addr | remove_netmask)" "$ipv4_dns1" >/dev/null 2>&1 || test_connect "$(get_first_ipv4_addr | remove_netmask)" "$ipv4_dns2" >/dev/null 2>&1; }; then
             echo "IPv4 has internet."
             ipv4_has_internet=true
         fi
-        if is_need_test_ipv6 && test_connect "$(get_first_ipv6_addr | remove_netmask)" "$ipv6_dns1" >/dev/null 2>&1; then
+        if is_need_test_ipv6 && { test_connect "$(get_first_ipv6_addr | remove_netmask)" "$ipv6_dns1" >/dev/null 2>&1 || test_connect "$(get_first_ipv6_addr | remove_netmask)" "$ipv6_dns2" >/dev/null 2>&1; }; then
             echo "IPv6 has internet."
             ipv6_has_internet=true
         fi


### PR DESCRIPTION
将 ipv4_dns2 和 ipv6_dns2 作为网络检测时的 fallback
增强对某些抽象网络环境的兼容（比如 1.1.1.1 不通而 8.8.8.8 通）
