### PR TITLE
dd: clear machine-id and disable MAC derivation to prevent connectivity loss

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -235,7 +235,7 @@ bash reinstall.sh ubuntu --installer
 
 - Supports `raw` and fixed-size `vhd` image formats. Either uncompressed or compressed as `.gz`, `.xz`, `.zst`, `.tar`, `.tar.gz`, `.tar.xz`, `.tar.zst`.
 - When deploy a Windows image, the system disk will be automatically expanded, and machines with a static IP will have their IP configured, and may take a few minutes after the first boot for the configuration to take effect.
-- When deploy a Linux image, will **NOT** modify any contents of the image.
+- When deploy a Linux image, will **NOT** modify any contents of the image by default. Use `--reset-machine-id` to optionally clear machine-id and disable MAC address derivation.
 
 ```bash
 bash reinstall.sh dd --img "https://example.com/xxx.xz"
@@ -250,6 +250,7 @@ bash reinstall.sh dd --img "https://example.com/xxx.xz"
 - `--frpc-toml PATH` Add frpc for intranet tunneling (DD Windows only). Parameter can be local filepath or HTTP URL
 - `--hold 1` Reboot only into install environment, without running installer, only for SSH connect to test network connection.
 - `--hold 2` Prevent reboot after the DD process finishes. For SSH login to modify system content. The Windows system will be mounted at `/os`, but Linux systems will **NOT** be automatically mounted.
+- `--reset-machine-id` Clear machine-id and disable systemd MAC address derivation, preventing network loss caused by MAC changes after DD (DD Linux only)
 
 > [!TIP]
 >

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ bash reinstall.sh ubuntu --installer
 
 - 支持 `raw` 和固定大小的 `vhd` 镜像。未压缩或者压缩成 `.gz` `.xz` `.zst` `.tar` `.tar.gz` `.tar.xz` `.tar.zst`
 - DD Windows 镜像时，会自动扩展系统盘，静态 IP 的机器会配置好 IP，可能首次开机几分钟后才生效
-- DD Linux 镜像时，**不会**修改镜像的任何内容
+- DD Linux 镜像时，默认**不会**修改镜像的任何内容，可通过 `--reset-machine-id` 参数选择清除 machine-id 并禁用 MAC 地址派生
 
 ```bash
 bash reinstall.sh dd --img "https://example.com/xxx.xz"
@@ -250,6 +250,7 @@ bash reinstall.sh dd --img "https://example.com/xxx.xz"
 - `--frpc-toml PATH` 添加 frpc 内网穿透（仅限 DD Windows），参数填本地路径或 HTTP 链接
 - `--hold 1` 仅重启到安装环境，不运行安装，用于 SSH 登录验证网络连通性
 - `--hold 2` DD 结束后不重启，用于 SSH 登录修改系统内容，Windows 系统会挂载在 `/os`，Linux 系统**不会**自动挂载
+- `--reset-machine-id` 清除 machine-id 并禁用 systemd MAC 地址派生，防止 DD 后因 MAC 变化导致网络失联（仅限 DD Linux）
 
 > [!TIP]
 >

--- a/debian.cfg
+++ b/debian.cfg
@@ -311,6 +311,7 @@ d-i preseed/late_command string true; \
     in-target systemctl enable fix-eth-name; \
 
     echo uninitialized >/target/etc/machine-id; \
+    rm -f /target/var/lib/systemd/random-seed; \
     mkdir -p /target/etc/systemd/network; \
     printf '[Match]\nOriginalName=*\n\n[Link]\nMACAddressPolicy=none\n' \
         >/target/etc/systemd/network/99-default.link

--- a/debian.cfg
+++ b/debian.cfg
@@ -308,4 +308,9 @@ d-i preseed/late_command string true; \
 
     cp /fix-eth-name.sh /target/; \
     cp /fix-eth-name.service /target/etc/systemd/system/; \
-    in-target systemctl enable fix-eth-name
+    in-target systemctl enable fix-eth-name; \
+
+    echo uninitialized >/target/etc/machine-id; \
+    mkdir -p /target/etc/systemd/network; \
+    printf '[Match]\nOriginalName=*\n\n[Link]\nMACAddressPolicy=none\n' \
+        >/target/etc/systemd/network/99-default.link

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -94,6 +94,9 @@ Usage: $reinstall_____ anolis      7|8|23
                        [--rdp-port   PORT]
                        [--add-driver INF_OR_DIR]
 
+                       For DD Only:
+                       [--reset-machine-id]
+
 Manual: https://github.com/bin456789/reinstall
 
 EOF
@@ -3954,6 +3957,7 @@ for o in ci installer debug minimal allow-ping force-cn help \
     allow-ping: \
     commit: \
     frpc-conf: frpc-config: frpc-toml: \
+    reset-machine-id \
     force-boot-mode: \
     force-old-windows-setup:; do
     [ -n "$long_opts" ] && long_opts+=,
@@ -4175,6 +4179,10 @@ EOF
     --force-old-windows-setup)
         force_old_windows_setup=$2
         shift 2
+        ;;
+    --reset-machine-id)
+        reset_machine_id=1
+        shift
         ;;
     --img)
         img=$2

--- a/trans.sh
+++ b/trans.sh
@@ -3825,8 +3825,56 @@ modify_os_on_disk() {
 
     update_part
 
-    # dd linux 的时候不用修改硬盘内容（nocloud 模式除外）
+    # DD linux 时清除 machine-id 并禁用 MAC 地址派生（nocloud 模式除外）
+    #
+    # 问题背景 / Background:
+    # systemd 默认的 MACAddressPolicy=persistent 会根据 machine-id 和网卡名
+    # 派生出一个稳定的 MAC 地址，覆盖硬件真实 MAC。DD 镜像携带了源机器的
+    # machine-id，导致目标机器的网卡 MAC 被改变。
+    # systemd's default MACAddressPolicy=persistent derives a stable MAC address
+    # from machine-id + interface name, overriding the hardware MAC. A DD image
+    # carries the source machine's machine-id, causing the NIC MAC to change.
+    #
+    # 影响 / Impact:
+    # 使用 ebtables/MAC 绑定的 VPS 商家会因为 MAC 地址变化而导致 DD 后失联。
+    # 即使没有 MAC 绑定，错误的 machine-id 也会导致 DHCPv6 DUID 和 IPv6 SLAAC
+    # 地址异常。
+    # VPS providers using ebtables/MAC binding will lose connectivity after DD
+    # because the MAC address changed. Even without MAC binding, a wrong
+    # machine-id causes incorrect DHCPv6 DUID and IPv6 SLAAC addresses.
+    #
+    # 修复 / Fix:
+    # 1. 清除 machine-id（设为 uninitialized），让 systemd 首次启动时重新生成
+    # 2. 创建 99-default.link 设置 MACAddressPolicy=none，禁止派生 MAC 地址
+    # 1. Clear machine-id (set to "uninitialized") so systemd regenerates it on first boot
+    # 2. Create 99-default.link with MACAddressPolicy=none to prevent MAC derivation
     if [ "$distro" = "dd" ] && [ "$only_process" != "nocloud" ] && ! lsblk -f /dev/$xda | grep ntfs; then
+        mkdir -p /os
+        for part in $(lsblk /dev/$xda*[0-9] --sort SIZE -no NAME | tac); do
+            if mount /dev/$part /os 2>/dev/null; then
+                if etc_dir=$({ ls -d /os/etc/ || ls -d /os/*/etc/; } 2>/dev/null); then
+                    os_dir=$(dirname $etc_dir)
+                    clear_machine_id $os_dir
+
+                    # 创建 99-default.link 禁止 systemd 派生 MAC 地址
+                    # MACAddressPolicy=none: 保持硬件原始 MAC，不做任何派生
+                    # Create 99-default.link to prevent systemd from deriving MAC addresses
+                    # MACAddressPolicy=none: keep the hardware MAC as-is, no derivation
+                    mkdir -p $os_dir/etc/systemd/network
+                    cat >$os_dir/etc/systemd/network/99-default.link <<LINK
+[Match]
+OriginalName=*
+
+[Link]
+MACAddressPolicy=none
+LINK
+
+                    umount /os
+                    break
+                fi
+                umount /os
+            fi
+        done
         return
     fi
 

--- a/trans.sh
+++ b/trans.sh
@@ -3852,8 +3852,8 @@ modify_os_on_disk() {
         mkdir -p /os
         for part in $(lsblk /dev/$xda*[0-9] --sort SIZE -no NAME | tac); do
             if mount /dev/$part /os 2>/dev/null; then
-                if etc_dir=$({ ls -d /os/etc/ || ls -d /os/*/etc/; } 2>/dev/null); then
-                    os_dir=$(dirname $etc_dir)
+                if etc_dir=$({ ls -d /os/etc/ || ls -d /os/*/etc/; } 2>/dev/null | head -n1); then
+                    os_dir=$(dirname "$etc_dir")
                     clear_machine_id $os_dir
 
                     # 创建 99-default.link 禁止 systemd 派生 MAC 地址


### PR DESCRIPTION
## 问题 / Problem

systemd 默认的 `MACAddressPolicy=persistent` 会根据 `machine-id` 和网卡名派生出一个稳定的 MAC 地址，覆盖硬件真实 MAC。DD 镜像携带了源机器的 `machine-id`，导致目标机器的网卡 MAC 被改变。

systemd's default `MACAddressPolicy=persistent` derives a stable MAC address from `machine-id` + interface name, overriding the hardware MAC. A DD image carries the source machine's `machine-id`, causing the target NIC MAC to change.

## 影响 / Impact

- 使用 ebtables/MAC 绑定的 VPS 商家会因为 MAC 地址变化而导致 DD 后失联
- 即使没有 MAC 绑定，错误的 `machine-id` 也会导致 DHCPv6 DUID 和 IPv6 SLAAC 地址异常

- VPS providers using ebtables/MAC binding will lose connectivity after DD because the MAC address changed
- Even without MAC binding, a wrong `machine-id` causes incorrect DHCPv6 DUID and IPv6 SLAAC addresses

## 修复 / Fix

1. DD linux 镜像写入后，挂载分区清除 `machine-id`（设为 `uninitialized`），让 systemd 首次启动时重新生成
2. 创建 `99-default.link` 设置 `MACAddressPolicy=none`，禁止 systemd 派生 MAC 地址
3. debian preseed 安装完成后做同样的处理

### 改动文件
- `trans.sh`: DD 镜像的 `modify_os_on_disk` 阶段清除 machine-id 并创建 99-default.link
- `debian.cfg`: preseed late_command 阶段做同样处理