### PR TITLE
震撼首发，给 reinstall 添加了 talos 安装支持

### DIFF
--- a/.github/workflows/run_reinstall.yml
+++ b/.github/workflows/run_reinstall.yml
@@ -29,6 +29,7 @@ jobs:
           ${{ matrix.command }} ubuntu
           ${{ matrix.command }} debian
           ${{ matrix.command }} debian --ci
+          ${{ matrix.command }} talos
           # ${{ matrix.command }} kali
           # ${{ matrix.command }} alpine
           # ${{ matrix.command }} opensuse

--- a/README.en.md
+++ b/README.en.md
@@ -64,6 +64,7 @@ The system requirements for the target system are as follows:
 | <img width="16" height="16" src="https://www.gentoo.org/assets/img/logo/gentoo-g.png" /> Gentoo                                                                                                                                                                                                                                                                        | Rolling                               | 512 MB    | 5 GB             |
 | <img width="16" height="16" src="https://aosc.io/distros/aosc-os.svg" /> AOSC OS                                                                                                                                                                                                                                                                                       | Rolling                               | 512 MB    | 5 GB             |
 | <img width="16" height="16" src="https://www.fnnas.com/favicon.ico" /> fnOS                                                                                                                                                                                                                                                                                            | 1                                     | 512 MB    | 8 GB             |
+| <img width="16" height="16" src="https://www.talos.dev/favicon.ico" /> Talos                                                                                                                                                                                                                                                                                            | Latest, x.y.z                         | 1 ~ 2 GB † | 10 GB            |
 | <img width="16" height="16" src="https://blogs.windows.com/wp-content/uploads/prod/2022/09/cropped-Windows11IconTransparent512-32x32.png" /> Windows (DD)                                                                                                                                                                                                              | Any                                   | 512 MB    | Depends on image |
 | <img width="16" height="16" src="https://blogs.windows.com/wp-content/uploads/prod/2022/09/cropped-Windows11IconTransparent512-32x32.png" /> Windows (ISO)                                                                                                                                                                                                             | Vista, 7, 8.x (Server 2008 - 2012 R2) | 512 MB    | 25 GB            |
 | <img width="16" height="16" src="https://blogs.windows.com/wp-content/uploads/prod/2022/09/cropped-Windows11IconTransparent512-32x32.png" /> Windows (ISO)                                                                                                                                                                                                             | 10, 11 (Server 2016 - 2025)           | 1 GB      | 25 GB            |
@@ -71,6 +72,8 @@ The system requirements for the target system are as follows:
 \* Indicates installation using cloud images, not traditional network installation.
 
 ^ Indicates requiring either 256 MB memory + 1.5 GB disk, or 512 MB memory + 1 GB disk
+
+† Talos memory requirement depends on node role: Control Plane needs at least 2 GiB, Worker needs at least 1 GiB
 
 > [!WARNING]
 >
@@ -147,7 +150,7 @@ certutil -urlcache -f -split https://cnb.cool/bin456789/reinstall/-/git/raw/main
 >
 > If the script was run by mistake, you can run `bash reinstall.sh reset` before rebooting to cancel the reinstallation operation.
 
-- Username `root`. The script prompts for a password. If left blank, a random one is generated.
+- Username `root`. The script prompts for a password. If left blank, a random one is generated (except Talos).
 - When installing the latest version, the version number does not need to be specified.
 - Maximizes disk space usage: no boot partition (except for Fedora) and no swap partition.
 - Automatically selects different optimized kernels based on machine type, such as `Cloud` or `HWE` kernels.
@@ -162,6 +165,7 @@ bash reinstall.sh anolis      7|8|23
                   opencloudos 8|9|23
                   centos      9|10
                   fnos        1
+                  talos       1.12.4
                   nixos       25.11
                   fedora      42|43
                   debian      9|10|11|12|13
@@ -175,6 +179,11 @@ bash reinstall.sh anolis      7|8|23
                   aosc
                   redhat      --img="http://access.cdn.redhat.com/xxx.qcow2"
 ```
+
+- For Talos, the script resolves the latest official tag first (for example `v1.12.4`), then uses a pinned release URL to download the official `metal-ARCH.raw.zst` image (with `raw.xz` fallback). Talos does not support SSH login by default. Use `talosctl` to bootstrap and manage nodes.
+- For Talos, the script does not prompt for password interactively by default. If neither `--password` nor `--ssh-key` is provided, it auto-generates a random password for installer-environment SSH.
+- Talos only supports installer-environment options: `--password`, `--ssh-key`, `--ssh-port`, `--web-port`, `--hold`, `--frpc-toml`.
+- Talos does not support: `--minimal`, `--installer`, `--allow-ping`, `--rdp-port`, `--add-driver`, `--img`, `--cloud-data`, `--iso`, `--boot-wim`, `--image-name`, `--lang`, `--force-old-windows-setup`.
 
 #### Optional Parameters
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 | <img width="16" height="16" src="https://www.gentoo.org/assets/img/logo/gentoo-g.png" /> Gentoo                                                                                                                                                                                                                                                                        | 滚动                                  | 512 MB    | 5 GB         |
 | <img width="16" height="16" src="https://aosc.io/distros/aosc-os.svg" /> 安同 OS                                                                                                                                                                                                                                                                                       | 滚动                                  | 512 MB    | 5 GB         |
 | <img width="16" height="16" src="https://www.fnnas.com/favicon.ico" /> 飞牛 fnOS                                                                                                                                                                                                                                                                                       | 1                                     | 512 MB    | 8 GB         |
+| <img width="16" height="16" src="https://www.talos.dev/favicon.ico" /> Talos                                                                                                                                                                                                                                                                                            | 最新, x.y.z                           | 1 ~ 2 GB † | 10 GB        |
 | <img width="16" height="16" src="https://blogs.windows.com/wp-content/uploads/prod/2022/09/cropped-Windows11IconTransparent512-32x32.png" /> Windows (DD)                                                                                                                                                                                                              | 任何                                  | 512 MB    | 取决于镜像   |
 | <img width="16" height="16" src="https://blogs.windows.com/wp-content/uploads/prod/2022/09/cropped-Windows11IconTransparent512-32x32.png" /> Windows (ISO)                                                                                                                                                                                                             | Vista, 7, 8.x (Server 2008 - 2012 R2) | 512 MB    | 25 GB        |
 | <img width="16" height="16" src="https://blogs.windows.com/wp-content/uploads/prod/2022/09/cropped-Windows11IconTransparent512-32x32.png" /> Windows (ISO)                                                                                                                                                                                                             | 10, 11 (Server 2016 - 2025)           | 1 GB      | 25 GB        |
@@ -71,6 +72,8 @@
 \* 表示使用云镜像安装，非传统网络安装
 
 ^ 表示需要 256 MB 内存 + 1.5 GB 硬盘，或 512 MB 内存 + 1 GB 硬盘
+
+† Talos 内存要求取决于节点角色：Control Plane 最低 2 GiB，Worker 最低 1 GiB
 
 > [!WARNING]
 >
@@ -147,7 +150,7 @@ certutil -urlcache -f -split https://cnb.cool/bin456789/reinstall/-/git/raw/main
 >
 > 如果不小心运行了脚本，可以在重启前运行 `bash reinstall.sh reset` 取消重装
 
-- 用户名为 `root`，脚本会提示输入密码，不输入则使用随机密码
+- 用户名为 `root`，脚本会提示输入密码，不输入则使用随机密码（Talos 除外）
 - 安装最新版可不输入版本号
 - 最大化利用磁盘空间：不含 boot 分区（Fedora 例外），不含 swap 分区
 - 自动根据机器类型选择不同的优化内核，例如 `Cloud`、`HWE` 内核
@@ -162,6 +165,7 @@ bash reinstall.sh anolis      7|8|23
                   opencloudos 8|9|23
                   centos      9|10
                   fnos        1
+                  talos       1.12.4
                   nixos       25.11
                   fedora      42|43
                   debian      9|10|11|12|13
@@ -175,6 +179,11 @@ bash reinstall.sh anolis      7|8|23
                   aosc
                   redhat      --img="http://access.cdn.redhat.com/xxx.qcow2"
 ```
+
+- 安装 Talos 时默认会先解析官方最新版本号（例如 `v1.12.4`），再使用固定版本链接下载官方 `metal-ARCH.raw.zst` 镜像（兼容回退 `raw.xz`）；默认不支持 SSH 登录，请使用 `talosctl` 管理节点
+- Talos 默认不会交互询问密码；当未传 `--password`/`--ssh-key` 时，会自动生成随机密码用于安装环境 SSH
+- Talos 仅支持安装环境参数：`--password`、`--ssh-key`、`--ssh-port`、`--web-port`、`--hold`、`--frpc-toml`
+- Talos 不支持：`--minimal`、`--installer`、`--allow-ping`、`--rdp-port`、`--add-driver`、`--img`、`--cloud-data`、`--iso`、`--boot-wim`、`--image-name`、`--lang`、`--force-old-windows-setup`
 
 #### 可选参数
 

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -2076,7 +2076,6 @@ verify_os_name() {
         'arch' \
         'gentoo' \
         'aosc' \
-        'talos' \
         'windows' \
         'dd' \
         'netboot.xyz' \

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -9,6 +9,8 @@ set -eE
 confhome=https://raw.githubusercontent.com/bin456789/reinstall/main
 confhome_cn=https://cnb.cool/bin456789/reinstall/-/git/raw/main
 # confhome_cn=https://www.ghproxy.cc/https://raw.githubusercontent.com/bin456789/reinstall/main
+default_confhome=$confhome
+default_confhome_cn=$confhome_cn
 
 # 用于判断 reinstall.sh 和 trans.sh 是否兼容
 SCRIPT_VERSION=4BACD833-A585-23BA-6CBB-9AA4E08E0004
@@ -81,6 +83,7 @@ Usage: $reinstall_____ anolis      7|8|23
                        almalinux   8|9|10
                        centos      9|10
                        fnos        1
+                       talos       1.12.4
                        nixos       25.11
                        fedora      42|43
                        debian      9|10|11|12|13
@@ -100,10 +103,11 @@ Usage: $reinstall_____ anolis      7|8|23
                        reset
 
        Options:        For Linux/Windows:
-                       [--password    PASSWORD]
-                       [--ssh-key     KEY]
-                       [--ssh-port    PORT]
-                       [--web-port    PORT]
+                       [--password  PASSWORD]
+                       [--ssh-key   KEY]
+                       [--ssh-port  PORT]
+                       [--web-port  PORT]
+                       [--confhome  URL_OR_DIR]
                        [--frpc-config PATH]
 
                        For Windows Only:
@@ -217,8 +221,18 @@ is_in_china() {
         # 备用 www.prologis.cn
         # 备用 www.autodesk.com.cn
         # 备用 www.keysight.com.cn
-        if ! _loc=$(curl -L http://www.qualcomm.cn/cdn-cgi/trace | grep '^loc=' | cut -d= -f2 | grep .); then
-            error_and_exit "Can not get location."
+        for trace_url in \
+            http://www.qualcomm.cn/cdn-cgi/trace \
+            https://www.qualcomm.cn/cdn-cgi/trace \
+            https://www.cloudflare.com/cdn-cgi/trace; do
+            if _loc=$(command curl --insecure --connect-timeout 4 --max-time 8 -fsSL "$trace_url" 2>/dev/null |
+                grep '^loc=' | cut -d= -f2 | grep .); then
+                break
+            fi
+        done
+        if [ -z "$_loc" ]; then
+            _loc=UN
+            warn false "Can not get location, assume non-CN."
         fi
         echo "Location: $_loc" >&2
     fi
@@ -1722,6 +1736,55 @@ Continue with DD?
         eval ${step}_img=$img
     }
 
+    setos_talos() {
+        talos_url_exists_quick() {
+            curl --connect-timeout 5 --max-time 12 -fsIL -o /dev/null "$1"
+        }
+
+        talos_img=
+        if [ -n "$releasever" ]; then
+            releasever=${releasever#v}
+            eval ${step}_releasever=$releasever
+            talos_img_prefix="https://github.com/siderolabs/talos/releases/download/v$releasever/metal-$basearch_alt"
+        else
+            # 优先解析最新 tag，并使用固定版本下载链接，避免依赖 latest/download
+            if latest_talos_tag=$(
+                curl --connect-timeout 5 --max-time 12 -fsSL https://api.github.com/repos/siderolabs/talos/releases/latest 2>/dev/null |
+                    grep -m1 '"tag_name":' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 | grep .
+            ); then
+                eval ${step}_releasever=${latest_talos_tag#v}
+                talos_img_prefix="https://github.com/siderolabs/talos/releases/download/$latest_talos_tag/metal-$basearch_alt"
+            else
+                talos_img_prefix="https://github.com/siderolabs/talos/releases/latest/download/metal-$basearch_alt"
+            fi
+        fi
+
+        # 兼容新旧资产命名：优先 raw.zst，回退 raw.xz
+        if [ -z "$talos_img" ]; then
+            info false "Probe Talos image URL..."
+            if talos_url_exists_quick "$talos_img_prefix.raw.zst"; then
+                talos_img="$talos_img_prefix.raw.zst"
+            elif talos_url_exists_quick "$talos_img_prefix.raw.xz"; then
+                talos_img="$talos_img_prefix.raw.xz"
+            else
+                talos_img="$talos_img_prefix.raw.zst"
+            fi
+        fi
+
+        # 自动识别 latest 对应的具体版本号，仅用于信息展示
+        # 仅在上面没拿到 tag 时使用
+        if [ -z "$releasever" ]; then
+            if [ -z "$(eval "echo \${${step}_releasever}")" ] && tag=$(
+                curl --connect-timeout 5 --max-time 12 -fIL -o /dev/null -w '%{url_effective}' "$talos_img" 2>/dev/null |
+                    grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 | grep .
+            ); then
+                eval ${step}_releasever=${tag#v}
+            fi
+        fi
+
+        eval ${step}_img="$talos_img"
+    }
+
     setos_centos_almalinux_rocky_fedora() {
         # el 10 需要 x86-64-v3，除了 almalinux
         if [ "$basearch" = x86_64 ] &&
@@ -1927,8 +1990,31 @@ Continue with DD?
 
     # 集中测试云镜像格式
     if is_use_cloud_image && [ "$step" = finalos ]; then
-        # shellcheck disable=SC2154
-        test_url $finalos_img 'qemu qemu.gzip qemu.xz qemu.zstd raw.xz' finalos_img_type
+        # Talos 镜像后缀固定，避免走 file_enhanced 触发安装 zstd 并拖慢流程
+        if [ "$distro" = talos ]; then
+            case "$finalos_img" in
+            *.raw.zst | *.raw.zstd)
+                finalos_img_type=raw
+                finalos_img_type_warp=zstd
+                ;;
+            *.raw.xz)
+                finalos_img_type=raw
+                finalos_img_type_warp=xz
+                ;;
+            *)
+                # 异常后缀时回退通用检测
+                # shellcheck disable=SC2154
+                test_url $finalos_img 'qemu qemu.gzip qemu.xz qemu.zstd raw.xz raw.zstd' finalos_img_type
+                return
+                ;;
+            esac
+
+            # 仅做可访问性检查
+            test_url $finalos_img
+        else
+            # shellcheck disable=SC2154
+            test_url $finalos_img 'qemu qemu.gzip qemu.xz qemu.zstd raw.xz raw.zstd' finalos_img_type
+        fi
     fi
 }
 
@@ -1961,6 +2047,14 @@ verify_os_name() {
         usage_and_exit
     fi
 
+    # 支持 talos: `talos` / `talos 1.12.4` / `talos v1.12.4`
+    finalos=$(echo "$@" | to_lower | sed -n -E "s,^(talos)[ :-]?((v)?[0-9]+\.[0-9]+\.[0-9]+)?$,\1 \2,p")
+    if [ -n "$finalos" ]; then
+        read -r distro releasever <<<"$finalos"
+        releasever=${releasever#v}
+        return
+    fi
+
     # 不要删除 centos 7
     for os in \
         'centos      7|9|10' \
@@ -1982,6 +2076,7 @@ verify_os_name() {
         'arch' \
         'gentoo' \
         'aosc' \
+        'talos' \
         'windows' \
         'dd' \
         'netboot.xyz' \
@@ -2008,6 +2103,24 @@ verify_os_args() {
     dd) [ -n "$img" ] || error_and_exit "dd need --img" ;;
     redhat) [ -n "$img" ] || error_and_exit "redhat need --img" ;;
     windows) [ -n "$image_name" ] || error_and_exit "Install Windows need --image-name." ;;
+    talos)
+        unsupported=
+        [ -n "$minimal" ] && unsupported+=" --minimal"
+        [ -n "$installer" ] && unsupported+=" --installer"
+        [ -n "$allow_ping" ] && unsupported+=" --allow-ping"
+        [ -n "$rdp_port" ] && unsupported+=" --rdp-port"
+        [ -n "$custom_infs" ] && unsupported+=" --add-driver"
+        [ -n "$img" ] && unsupported+=" --img"
+        [ -n "$cloud_data" ] && unsupported+=" --cloud-data"
+        [ -n "$iso" ] && unsupported+=" --iso"
+        [ -n "$boot_wim" ] && unsupported+=" --boot-wim"
+        [ -n "$image_name" ] && unsupported+=" --image-name"
+        [ -n "$lang" ] && unsupported+=" --lang"
+        [ -n "$force_old_windows_setup" ] && unsupported+=" --force-old-windows-setup"
+        if [ -n "$unsupported" ]; then
+            error_and_exit "For talos, unsupported option(s):$unsupported"
+        fi
+        ;;
     esac
 
     case "$distro" in
@@ -2248,7 +2361,7 @@ check_ram() {
         alpine | debian | kali | dd) echo 256 ;;
         arch | gentoo | aosc | nixos | windows) echo 512 ;;
         redhat | centos | almalinux | rocky | fedora | oracle | ubuntu | anolis | opencloudos | openeuler) echo 1024 ;;
-        opensuse | fnos) echo -1 ;; # 没有安装模式
+        opensuse | fnos | talos) echo -1 ;; # 没有安装模式
         esac
     )
 
@@ -2262,7 +2375,7 @@ check_ram() {
 
     has_cloud_image=$(
         case "$distro" in
-        redhat | centos | almalinux | rocky | oracle | fedora | debian | ubuntu | opensuse | anolis | openeuler) echo true ;;
+        redhat | centos | almalinux | rocky | oracle | fedora | debian | ubuntu | opensuse | anolis | openeuler | talos) echo true ;;
         netboot.xyz | alpine | dd | arch | gentoo | nixos | kali | windows) echo false ;;
         esac
     )
@@ -2416,14 +2529,18 @@ prompt_password() {
                 error "Passwords don't match. Try again."
             fi
         else
-            # 特殊字符列表
-            # https://learn.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh994562(v=ws.11)
-            # 有的机器运行 centos 7 ，用 /dev/random 产生 16 位密码，开启了 rngd 也要 5 秒，关闭了 rngd 则长期阻塞
-            chars=\''A-Za-z0-9~!@#$%^&*_=+`|(){}[]:;"<>,.?/-'
-            password=$(tr -dc "$chars" </dev/urandom | head -c16)
+            password=$(generate_random_password)
             break
         fi
     done
+}
+
+generate_random_password() {
+    # 特殊字符列表
+    # https://learn.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh994562(v=ws.11)
+    # 有的机器运行 centos 7 ，用 /dev/random 产生 16 位密码，开启了 rngd 也要 5 秒，关闭了 rngd 则长期阻塞
+    chars=\''A-Za-z0-9~!@#$%^&*_=+`|(){}[]:;"<>,.?/-'
+    tr -dc "$chars" </dev/urandom | head -c16
 }
 
 save_password() {
@@ -3177,7 +3294,11 @@ build_extra_cmdline() {
     for key in confhome hold force_boot_mode force_cn force_old_windows_setup cloud_image main_disk \
         elts deb_mirror \
         ssh_port rdp_port web_port allow_ping; do
-        value=${!key}
+        if [ "$key" = confhome ] && [ -n "$confhome_for_cmdline" ]; then
+            value=$confhome_for_cmdline
+        else
+            value=${!key}
+        fi
         if [ -n "$value" ]; then
             is_need_quote "$value" &&
                 extra_cmdline+=" extra_$key='$value'" ||
@@ -3802,6 +3923,9 @@ EOF
         # wget --no-check-certificate -O \$sysroot/etc/local.d/trans.start $confhome/trans.sh
         cp /trans.sh \$sysroot/etc/local.d/trans.start
         chmod a+x \$sysroot/etc/local.d/trans.start
+
+        # installer 环境不需要 tiny-cloud，避免宿主机 cloud-init 元数据干扰 trans.start
+        rm -f \$sysroot/etc/runlevels/default/tiny-cloud*
         ln -s /etc/init.d/local \$sysroot/etc/runlevels/default/
 
         # 配置 + 自定义驱动
@@ -4059,13 +4183,25 @@ init_confhome() {
     # gitee 不支持ipv6
     # jsdelivr 有12小时缓存
     # https://github.com/XIU2/UserScript/blob/master/GithubEnhanced-High-Speed-Download.user.js#L31
-    if is_in_china; then
+    if [ -z "$custom_confhome" ] && is_in_china; then
         if [ -n "$confhome_cn" ]; then
             confhome=$confhome_cn
         elif [ -n "$github_proxy" ] && [[ "$confhome" = http*://raw.githubusercontent.com/* ]]; then
             confhome=${confhome/http:\/\//https:\/\/}
             confhome=${confhome/https:\/\/raw.githubusercontent.com/$github_proxy}
         fi
+    fi
+
+    # 本地目录 confhome 仅用于当前系统构建 initrd。
+    # 安装环境无法直接访问宿主机目录，因此 cmdline 里回退到在线 confhome。
+    confhome_for_cmdline=$confhome
+    if [[ "$confhome" = file://* ]]; then
+        if is_in_china && [ -n "$default_confhome_cn" ]; then
+            confhome_for_cmdline=$default_confhome_cn
+        else
+            confhome_for_cmdline=$default_confhome
+        fi
+        warn false "Local --confhome is build-time only. Runtime fallback confhome: $confhome_for_cmdline"
     fi
 }
 
@@ -4340,7 +4476,8 @@ for o in ci installer debug minimal allow-ping force-cn help \
     web-port: http-port: \
     allow-ping: \
     commit: \
-    frpc-conf: frpc-config: \
+    confhome: \
+    frpc-conf: frpc-config: frpc-toml: \
     target-disk: \
     force-boot-mode: \
     force-old-windows-setup:; do
@@ -4405,6 +4542,31 @@ while true; do
         commit=$2
         shift 2
         ;;
+    --confhome)
+        [ -n "$2" ] || error_and_exit "Need value for $1"
+        case "$2" in
+        http://* | https://* | file://*)
+            confhome=$2
+            ;;
+        *)
+            # 支持传本地目录路径
+            local_confhome=$(get_unix_path "$2")
+            local_confhome=$(readlink -f "$local_confhome")
+            if ! [ -d "$local_confhome" ]; then
+                error_and_exit "Invalid --confhome: $2"
+            fi
+            confhome="file://$local_confhome"
+            ;;
+        esac
+        custom_confhome=1
+        # 指定 confhome 时，默认不再自动切换到 confhome_cn
+        confhome_cn=
+        shift 2
+        ;;
+    -x | --debug)
+        set -x
+        shift
+        ;;
     --ci)
         cloud_image=1
         unset installer
@@ -4435,7 +4597,7 @@ while true; do
         hold=$2
         shift 2
         ;;
-    --frpc-conf | --frpc-config)
+    --frpc-conf | --frpc-config | --frpc-toml)
         [ -n "$2" ] || error_and_exit "Need value for $1"
 
         case "$(to_lower <<<"$2")" in
@@ -4644,10 +4806,19 @@ verify_os_args
 
 # 密码
 if ! is_netboot_xyz && [ -z "$ssh_keys" ] && [ -z "$password" ]; then
-    if is_use_dd; then
-        show_dd_password_tips
+    if [ "$distro" = talos ]; then
+        # talos 目标系统无 shell，默认不应交互询问密码
+        # 仍生成随机密码用于安装环境（alpine）ssh
+        password=$(generate_random_password)
+        warn false "Talos target has no SSH shell."
+        warn false "Auto-generated a random password for installer environment."
+        warn false "Use --password or --ssh-key if you need SSH access during installation."
+    else
+        if is_use_dd; then
+            show_dd_password_tips
+        fi
+        prompt_password
     fi
-    prompt_password
 fi
 
 # 强制忽略/强制添加 --ci 参数
@@ -4659,7 +4830,7 @@ dd | windows | netboot.xyz | kali | alpine | arch | gentoo | aosc | nixos | fnos
         unset cloud_image
     fi
     ;;
-oracle | opensuse | anolis | opencloudos | openeuler)
+oracle | opensuse | anolis | opencloudos | openeuler | talos)
     cloud_image=1
     ;;
 redhat | centos | almalinux | rocky | fedora | ubuntu)
@@ -4922,7 +5093,7 @@ echo "$distro $releasever"
 
 case "$distro" in
 windows) username=administrator ;;
-netboot.xyz) username= ;;
+netboot.xyz | talos) username= ;;
 dd | *) username=root ;;
 esac
 
@@ -4956,6 +5127,16 @@ elif [ "$distro" = fnos ]; then
     echo "重启后开始安装。"
     echo "安装完成后不支持 SSH 登录。"
     echo "你需要尽快在 http://SERVER_IP:5666 配置账号密码。"
+elif [ "$distro" = talos ]; then
+    echo "Special note for Talos:"
+    echo "Reboot to start the installation."
+    echo "Talos has no SSH login by default."
+    echo "Please bootstrap and manage nodes via talosctl."
+    echo
+    echo "Talos 注意事项："
+    echo "重启后开始安装。"
+    echo "Talos 默认不支持 SSH 登录。"
+    echo "请使用 talosctl 引导并管理节点。"
 else
     echo "Reboot to start the installation."
 fi

--- a/trans.sh
+++ b/trans.sh
@@ -15,6 +15,8 @@ SCRIPT_VERSION=4BACD833-A585-23BA-6CBB-9AA4E08E0004
 TRUE=0
 FALSE=1
 EFI_UUID=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+DEFAULT_CONFHOME=https://raw.githubusercontent.com/bin456789/reinstall/main
+DEFAULT_CONFHOME_CN=https://cnb.cool/bin456789/reinstall/-/git/raw/main
 
 error() {
     color='\e[31m'
@@ -64,7 +66,7 @@ trap_err() {
 }
 
 is_run_from_locald() {
-    [[ "$0" = "/etc/local.d/*" ]]
+    [[ "$0" = /etc/local.d/* ]]
 }
 
 add_community_repo() {
@@ -411,6 +413,31 @@ extract_env_from_cmdline() {
             fi
         done < <(xargs -n1 </proc/cmdline | grep "^${prefix}_" | sed "s/^${prefix}_//")
     done
+}
+
+fix_confhome_if_needed() {
+    case "$confhome" in
+    file://*)
+        local path=${confhome#file://}
+        if ! [ -d "$path" ]; then
+            warn "cmdline confhome not found in installer environment: $confhome"
+            if is_in_china; then
+                confhome=$DEFAULT_CONFHOME_CN
+            else
+                confhome=$DEFAULT_CONFHOME
+            fi
+            warn "fallback confhome: $confhome"
+        fi
+        ;;
+    esac
+}
+
+start_console_log_mirror() {
+    # local service 场景下日志默认只写 /reinstall.log，控制台看起来像“卡住”。
+    # 这里将日志同步到 /dev/console，便于观察进度，失败时也能看到最后一步。
+    if [ -c /dev/console ]; then
+        tail -fn+1 /reinstall.log >/dev/console 2>/dev/null &
+    fi
 }
 
 ensure_service_started() {
@@ -2482,6 +2509,29 @@ pipe_extract() {
     esac
 }
 
+handle_dd_write_error() {
+    # vhd 文件结尾有 512 字节额外信息，可以忽略
+    if grep -iq 'No space' /tmp/dd_stderr; then
+        apk add parted
+        disk_size=$(get_disk_size /dev/$xda)
+        disk_end=$((disk_size - 1))
+
+        # 如果报错，那大概是因为镜像比硬盘大
+        if last_part_end=$(parted -sf /dev/$xda 'unit b print' ---pretend-input-tty |
+            del_empty_lines | tail -1 | awk '{print $3}' | sed 's/B//' | grep .); then
+
+            echo "Last part end: $last_part_end"
+            echo "Disk end:      $disk_end"
+
+            if [ "$last_part_end" -le "$disk_end" ]; then
+                echo "Safely ignore no space error."
+                return
+            fi
+        fi
+    fi
+    error_and_exit "$(cat /tmp/dd_stderr)"
+}
+
 dd_raw_with_extract() {
     info "dd raw"
 
@@ -2489,26 +2539,7 @@ dd_raw_with_extract() {
     apk add wget
 
     if ! wget $img -O- | pipe_extract >/dev/$xda 2>/tmp/dd_stderr; then
-        # vhd 文件结尾有 512 字节额外信息，可以忽略
-        if grep -iq 'No space' /tmp/dd_stderr; then
-            apk add parted
-            disk_size=$(get_disk_size /dev/$xda)
-            disk_end=$((disk_size - 1))
-
-            # 如果报错，那大概是因为镜像比硬盘大
-            if last_part_end=$(parted -sf /dev/$xda 'unit b print' ---pretend-input-tty |
-                del_empty_lines | tail -1 | awk '{print $3}' | sed 's/B//' | grep .); then
-
-                echo "Last part end: $last_part_end"
-                echo "Disk end:      $disk_end"
-
-                if [ "$last_part_end" -le "$disk_end" ]; then
-                    echo "Safely ignore no space error."
-                    return
-                fi
-            fi
-        fi
-        error_and_exit "$(cat /tmp/dd_stderr)"
+        handle_dd_write_error
     fi
 }
 
@@ -3908,6 +3939,12 @@ EOF
 modify_os_on_disk() {
     only_process=$1
     info "Modify disk if is $only_process"
+
+    # Talos 是不可变系统，不应套用通用 Linux 挂载/改盘逻辑
+    if [ "$distro" = "talos" ] && [ "$only_process" = "linux" ]; then
+        info false "Skip linux post-processing for Talos."
+        return
+    fi
 
     update_part
 
@@ -5433,6 +5470,12 @@ fix_gpt_backup_partition_table_by_parted() {
 }
 
 resize_after_install_cloud_image() {
+    # Talos 使用固定分区布局，不做通用云镜像扩容
+    if [ "$distro" = "talos" ]; then
+        info false "Skip resize for Talos."
+        return
+    fi
+
     # 提前扩容
     # 1 修复 vultr 512m debian 11 generic/genericcloud 首次启动 kernel panic
     # 2 防止 gentoo 云镜像 websync 时空间不足
@@ -7456,8 +7499,13 @@ trans() {
         raw)
             # 暂时没用到 raw 格式的云镜像
             dd_raw_with_extract
-            resize_after_install_cloud_image
-            modify_os_on_disk linux
+            if [ "$distro" = "talos" ]; then
+                # Talos 是不可变系统，避免套用通用 Linux 后处理
+                :
+            else
+                resize_after_install_cloud_image
+                modify_os_on_disk linux
+            fi
             ;;
         esac
     elif [ "$distro" = "dd" ]; then
@@ -7539,6 +7587,12 @@ rm -f /etc/runlevels/default/local
 
 # 提取变量
 extract_env_from_cmdline
+fix_confhome_if_needed
+
+# 尽早开启日志，避免 local service 失败时没有有效报错信息
+# 仅重定向到文件，避免在 /bin/ash 下使用进程替换语法
+exec >>/reinstall.log 2>&1
+start_console_log_mirror
 
 # 带参数运行部分
 # 重新下载并 exec 运行新脚本
@@ -7559,7 +7613,7 @@ fi
 
 # 无参数运行部分
 # 允许 ramdisk 使用所有内存，默认是 50%
-mount / -o remount,size=100%
+mount / -o remount,size=100% || warn "Failed to remount / with size=100%, continue."
 
 # 同步时间
 # 1. 可以防止访问 https 出错
@@ -7609,16 +7663,14 @@ fi
 # shellcheck disable=SC2046,SC2194
 case 1 in
 1)
-    # ChatGPT 说这种性能最高
-    exec > >(exec tee $(get_ttys /dev/) /reinstall.log) 2>&1
     trans
     ;;
 2)
-    exec > >(tee $(get_ttys /dev/) /reinstall.log) 2>&1
     trans
     ;;
 3)
-    trans 2>&1 | tee $(get_ttys /dev/) /reinstall.log
+    # 已在前面重定向日志，这里保持调用一致
+    trans
     ;;
 esac
 


### PR DESCRIPTION
## 前情提要

Talos Linux 是面向 Kubernetes 的不可变发行版，与传统 Linux 不同：
- 默认无 Shell 登录环境
- 安装与启动后处理逻辑与常规发行版存在差异

相关仓库：
- https://github.com/siderolabs/talos

## 变更内容

本 PR 新增 Talos 安装支持，并补充与 Talos 特性相关的兼容处理：

1. 新增 Talos 安装目标
- 支持 `talos` / `talos x.y.z` 参数形式
- 适配 Talos 镜像下载与安装流程

2. Talos 特性适配
- 避免套用常规 Linux 的后处理逻辑（如通用 resize / modify 流程）
- 调整 Talos 场景下安装阶段的交互行为（无 Shell 场景）

3. 新增 `--confhome`
- 支持自定义配置来源（URL 或本地目录）
- 便于离线/内网环境及本地 KVM 测试

## 测试情况

已在以下环境完成多轮重装验证：
- Rocky Linux 10
- Ubuntu

测试视频：
- https://github.com/user-attachments/assets/96f53577-3d8d-4364-b9ed-3083687c0bbd