### PR TITLE
feat: 新增 tty2web 用于替换 Nginx/websocketd 作为 logviewer

### DIFF
--- a/debian.cfg
+++ b/debian.cfg
@@ -163,18 +163,48 @@ d-i preseed/early_command string true; \
             echo '    TERM=screen screen -xp1'; \
         } >>/etc/motd; \
         mem=$(grep ^MemTotal: /proc/meminfo | { read -r _ y _; echo "$((y / 1024))"; }); \
-        if command -v websocketd && [ "$mem" -ge 400 ]; then \
-            for _ in {1..10}; do \
-                if wget "$confhome/logviewer.html" -O /tmp/index.html; then \
-                    break; \
-                fi; \
-                sleep 5; \
-            done; \
+        if [ "$mem" -ge 400 ]; then \
             if [ -z "$web_port" ]; then \
                 web_port=80; \
             fi; \
-            run_as_service_with_screen websocketd --port 80 --loglevel=fatal --staticdir=/tmp \
-                sh -c "tail -fn+0 /var/log/syslog | tr '\r' '\n' | grep -Fiv -e password -e token" ; \
+            arch=$(uname -m); \
+            case "$arch" in \
+                x86_64)  tty2web_arch="linux_amd64" ;; \
+                i386|i686) tty2web_arch="linux_386" ;; \
+                aarch64) tty2web_arch="linux_arm" ;; \
+                armv7l|armhf) tty2web_arch="linux_arm" ;; \
+                mips) tty2web_arch="linux_mips" ;; \
+                mips64) tty2web_arch="linux_mips64" ;; \
+                mips64le) tty2web_arch="linux_mips64le" ;; \
+                mipsle) tty2web_arch="linux_mipsle" ;; \
+                s390x) tty2web_arch="linux_s390x" ;; \
+                *) tty2web_arch="" ;; \
+            esac; \
+            tty2web_url="https://github.com/kost/tty2web/releases/latest/download/tty2web_${tty2web_arch}"; \
+            tty2web_downloaded=false; \
+            if [ -n "$tty2web_arch" ]; then \
+                for _ in {1..10}; do \
+                    if wget "$tty2web_url" -O /tmp/tty2web; then \
+                        chmod +x /tmp/tty2web; \
+                        tty2web_downloaded=true; \
+                        break; \
+                    fi; \
+                    sleep 5; \
+                done; \
+            fi; \
+            if [ "$tty2web_downloaded" = "true" ]; then \
+                run_as_service_with_screen /tmp/tty2web --port "$web_port" --permit-write=false \
+                    sh -c "tail -fn+0 /var/log/syslog | tr '\r' '\n' | grep -Fiv -e password -e token"; \
+            elif command -v websocketd; then \
+                for _ in {1..10}; do \
+                    if wget "$confhome/logviewer.html" -O /tmp/index.html; then \
+                        break; \
+                    fi; \
+                    sleep 5; \
+                done; \
+                run_as_service_with_screen websocketd --port "$web_port" --loglevel=fatal --staticdir=/tmp \
+                    sh -c "tail -fn+0 /var/log/syslog | tr '\r' '\n' | grep -Fiv -e password -e token"; \
+            fi; \
         fi; \
     fi; \
 

--- a/trans.sh
+++ b/trans.sh
@@ -307,6 +307,68 @@ setup_websocketd() {
         stdbuf -oL -eL sh -c "tail -fn+0 /reinstall.log | tr '\r' '\n' | grep -Fiv -e password -e token" &
 }
 
+setup_tty2web() {
+    # 检测系统架构
+    local arch tty2web_arch tty2web_url
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64)  tty2web_arch="linux_amd64" ;;
+        i386|i686) tty2web_arch="linux_386" ;;
+        aarch64) tty2web_arch="linux_arm" ;;
+        armv7l|armhf) tty2web_arch="linux_arm" ;;
+        mips) tty2web_arch="linux_mips" ;;
+        mips64) tty2web_arch="linux_mips64" ;;
+        mips64le) tty2web_arch="linux_mips64le" ;;
+        mipsle) tty2web_arch="linux_mipsle" ;;
+        s390x) tty2web_arch="linux_s390x" ;;
+        *)
+            echo "Unsupported architecture: $arch, falling back to websocketd"
+            setup_websocketd
+            return
+            ;;
+    esac
+
+    # 获取最新版本下载 URL
+    # 使用 GitHub API 获取最新 release 的下载链接
+    tty2web_url="https://github.com/kost/tty2web/releases/latest/download/tty2web_${tty2web_arch}"
+
+    # 尝试下载 tty2web
+    local download_success=false
+    for i in $(seq 1 10); do
+        if wget "$tty2web_url" -O /tmp/tty2web 2>/dev/null; then
+            download_success=true
+            break
+        fi
+        echo "Download attempt $i failed, retrying..."
+        sleep 5
+    done
+
+    if [ "$download_success" != "true" ]; then
+        echo "Failed to download tty2web, falling back to websocketd"
+        setup_websocketd
+        return
+    fi
+
+    # 赋予执行权限
+    chmod +x /tmp/tty2web
+
+    # 设置端口
+    if [ -z "$web_port" ]; then
+        web_port=80
+    fi
+
+    # 停止其他可能运行的服务
+    pkill websocketd || true
+    pkill nginx || true
+
+    # 使用 tty2web 启动日志查看服务
+    # --permit-write 允许客户端写入（可选）
+    # 使用 tail 实时跟踪日志，过滤敏感信息
+    /tmp/tty2web --port "$web_port" \
+        --permit-write=false \
+        sh -c "tail -fn+0 /reinstall.log | tr '\r' '\n' | grep -Fiv -e password -e token" &
+}
+
 get_approximate_ram_size() {
     # lsmem 需要 util-linux
     if false && is_have_cmd lsmem; then
@@ -327,7 +389,8 @@ setup_web_if_enough_ram() {
         # lighttpd 虽然运行占用内存少，但安装占用空间大
         # setup_lighttpd
         # setup_nginx
-        setup_websocketd
+        # setup_websocketd
+        setup_tty2web
     fi
 }
 


### PR DESCRIPTION
- 新增 setup_tty2web 函数，支持自动下载并启动 tty2web
- 支持多种架构：x86_64, i386, aarch64, arm, mips 等
- 下载失败时自动回退到 websocketd
- 修改 trans.sh 和 debian.cfg 优先使用 tty2web
- tty2web 更轻量也更优雅，自带 Web 界面和 WebSocket 支持