### PR TITLE
core: 实验性支持重装 Linux 时指定文件系统类型和参数

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -224,6 +224,16 @@ Install Ubuntu using ISO
 bash reinstall.sh ubuntu --installer
 ```
 
+Appoint root partition file system type and parameters
+
+- `--fs-type ...` Specifies the root partition file system. Currently available values are `default|ext4|xfs`, with the default being `default`, which maintains the distribution's default logic. **`xfs` requires XFS v5 format, corresponding to a minimum Linux 5.10 kernel**. Therefore, it only supports Debian 11+, Ubuntu 22.04+, Anolis 8+, OpenCloudOS 9+, openEuler 22.03+, Oracle cloud image templates, and rolling distributions that use mkfs. **It does not support** Ubuntu 20.04-, Debian 10-, Anolis 7, OpenCloudOS 8, openEuler 20.03, AlmaLinux/Rocky 8- and FNOS.
+- `--fs-options ...` are parameters appended to `mkfs`, only applicable to the root partition, and must be used together with `--fs-type ext4|xfs` (not supported with `default`). Only supports installation schemes where `trans.sh` directly executes `mkfs` on the root partition; installer paths or direct writing in cloud image paths will report errors during parameter checking.
+
+```bash
+bash reinstall.sh ubuntu 22.04 --fs-type ext4 --fs-options '-m 0'
+bash reinstall.sh ubuntu 26.04 --fs-type xfs --fs-options '-m reflink=1,rmapbt=0'
+```
+
 </details>
 
 ### Feature 2: DD RAW image to hard disk

--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ ISO 安装 Ubuntu
 bash reinstall.sh ubuntu --installer
 ```
 
+指定根分区文件系统类型和参数
+
+- `--fs-type ...` 指定根分区文件系统。目前可用值为`default|ext4|xfs`，默认值为 `default` 即保持发行版默认逻辑。**`xfs` 要求 XFS v5 格式，对应需要最低 Linux 5.10 内核**。因此仅支持 Debian 11+、Ubuntu 22.04+、Anolis 8+、OpenCloudOS 9+、openEuler 22.03+、Oracle 云镜像模板，以及使用 mkfs 的滚动发行版。**不支持** Ubuntu 20.04-、Debian 10-、Anolis 7、OpenCloudOS 8、openEuler 20.03、AlmaLinux/Rocky 8-、FNOS。
+- `--fs-options ...` 是追加到 `mkfs` 的参数，仅作用于根分区，且必须和 `--fs-type ext4|xfs`一起使用（不支持 `default`）。仅支持由 `trans.sh` 直接执行根分区 `mkfs` 的安装方案；安装器路径或直接写入云镜像路径会在参数检查时直接报错。
+
+```bash
+bash reinstall.sh ubuntu 22.04 --fs-type ext4 --fs-options '-m 0'
+bash reinstall.sh ubuntu 26.04 --fs-type xfs --fs-options '-m reflink=1,rmapbt=0'
+```
+
 </details>
 
 ### 功能 2: DD RAW 镜像到硬盘

--- a/redhat.cfg
+++ b/redhat.cfg
@@ -11,9 +11,9 @@ reboot
 # 分区
 %include /tmp/include-disk-only-use
 %include /tmp/include-bootloader
+%include /tmp/include-root-fstype
 clearpart --all --initlabel
 reqpart # 如果需要，自动创建 efi 或 biosboot 分区
-part / --fstype=xfs --grow
 
 # 软件
 %packages --ignoremissing # el9 minimal.iso fedora Server repo/iso 没有 tuned
@@ -38,11 +38,19 @@ distro=$(awk -F: '{ print $3 }' </etc/system-release-cpe)
 releasever=$(awk -F: '{ print $5 }' </etc/system-release-cpe)
 
 # 重新整理 extra，grub把两侧的引号吃掉了，eval出错，要重新添加引号
-# 提取 extra_confhome extra_mirrorlist extra_main_disk
+# 提取 extra_confhome extra_mirrorlist extra_main_disk extra_fs_type
 prefix=extra
 for var in $(grep -o "\b${prefix}_[^ ]*" /proc/cmdline | xargs); do
     eval "$(echo "$var" | sed -E "s/${prefix}_([^=]*)=(.*)/\1='\2'/")"
 done
+
+# root 文件系统，默认 xfs
+include=/tmp/include-root-fstype
+case "$fs_type" in
+ext4 | xfs) root_fstype=$fs_type ;;
+*) root_fstype=xfs ;;
+esac
+echo "part / --fstype=$root_fstype --grow" >$include
 
 # centos7 证书链未更新，需要 --no-check-certificate
 

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -108,6 +108,10 @@ Usage: $reinstall_____ anolis      7|8|23
                        [--web-port    PORT]
                        [--frpc-config PATH]
 
+                       For Linux Only (Experimental):
+                       [--fs-type     default|ext4|xfs]
+                       [--fs-options  MKFS_OPTIONS]
+
                        For Windows Only:
                        [--allow-ping]
                        [--rdp-port    PORT]
@@ -318,6 +322,144 @@ is_digit() {
 
 is_port_valid() {
     is_digit "$1" && [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
+
+is_linux_reinstall_target() {
+    case "$distro" in
+    dd | windows | netboot.xyz | reset) return 1 ;;
+    *) return ;;
+    esac
+}
+
+is_fs_args_set() {
+    [ "$fs_type_set" = 1 ] || [ -n "$fs_options" ]
+}
+
+is_fs_options_valid() {
+    local value=$1
+
+    [ -n "$value" ] || return 1
+    [[ "$value" != *$'\n'* ]] || return 1
+    [[ "$value" != *$'\r'* ]] || return 1
+
+    # 只允许安全字符，避免通过 cmdline/ash 执行时出现注入风险
+    [[ "$value" != *"'"* ]] || return 1
+    [[ "$value" != *'"'* ]] || return 1
+    [[ "$value" != *'`'* ]] || return 1
+    [[ "$value" != *'$'* ]] || return 1
+    [[ "$value" != *'\\'* ]] || return 1
+    grep -Eq '^[0-9A-Za-z[:space:]._,:=/+^%-]+$' <<<"$value"
+}
+
+get_install_fs_backend() {
+    if ! is_linux_reinstall_target; then
+        echo unsupported
+        return
+    fi
+
+    # debian/kali 传统安装走安装器分区流程；debian cloud image 走直接写盘流程
+    if is_distro_like_debian; then
+        if is_use_cloud_image; then
+            echo image
+        else
+            echo installer
+        fi
+        return
+    fi
+
+    if is_use_cloud_image; then
+        # 这几个系统云镜像通过复制文件 + mkfs 重建系统分区
+        case "$distro" in
+        centos | almalinux | rocky | oracle | redhat | anolis | opencloudos | openeuler | ubuntu)
+            echo mkfs
+            ;;
+        *)
+            # 其他云镜像通常直接 dd，不稳定支持重建文件系统
+            echo image
+            ;;
+        esac
+        return
+    fi
+
+    case "$distro" in
+    alpine | arch | gentoo | aosc | nixos | fnos) echo mkfs ;;
+    *) echo installer ;;
+    esac
+}
+
+verify_xfs_compatibility() {
+    local fs_backend=$1
+
+    # Linux 5.10 引入了 XFS v5 解决了 2038 年问题并标记 XFS v4 于 2030 年移除
+    # 因此只放行已知默认内核达到 5.10+ 的发行版/版本线
+    case "$distro:$releasever" in
+    ubuntu:18.* | ubuntu:20.*)
+        error_and_exit "xfs is only supported on Ubuntu 22.04+ in this script."
+        ;;
+    debian:9 | debian:10)
+        error_and_exit "xfs is only supported on Debian 11+ in this script."
+        ;;
+    anolis:7)
+        error_and_exit "xfs is only supported on Anolis 8+ in this script."
+        ;;
+    opencloudos:8)
+        error_and_exit "xfs is only supported on OpenCloudOS 9+ in this script."
+        ;;
+    openeuler:20.03)
+        error_and_exit "xfs is only supported on openEuler 22.03+ in this script."
+        ;;
+    almalinux:8 | rocky:8)
+        error_and_exit "xfs is only supported on AlmaLinux/Rocky 9+ in this script."
+        ;;
+    fnos:*)
+        error_and_exit "xfs is not supported for fnos in this script."
+        ;;
+    esac
+
+    if [ "$fs_backend" = image ]; then
+        error_and_exit "xfs is not supported for image-based install path of $distro."
+    fi
+}
+
+verify_fs_args() {
+    local fs_backend
+
+    if ! is_fs_args_set; then
+        return
+    fi
+
+    if ! is_linux_reinstall_target; then
+        error_and_exit "--fs-type/--fs-options are only supported for Linux reinstall targets."
+    fi
+
+    if [ -n "$fs_options" ] && [ "$fs_type_set" != 1 ]; then
+        error_and_exit "--fs-options requires explicit --fs-type ext4 or --fs-type xfs."
+    fi
+
+    fs_backend=$(get_install_fs_backend)
+
+    if [ "$fs_type_set" = 1 ]; then
+        case "$fs_type" in
+        default | ext4 | xfs) ;;
+        *) error_and_exit "Invalid --fs-type value: $fs_type" ;;
+        esac
+
+        if [ "$fs_type" != default ] && [ "$fs_backend" = image ]; then
+            error_and_exit "--fs-type is not supported for image-based install path of $distro."
+        fi
+
+        if [ "$fs_type" = xfs ]; then
+            verify_xfs_compatibility "$fs_backend"
+        fi
+    fi
+
+    if [ -n "$fs_options" ] && [ "$fs_type" = default ]; then
+        error_and_exit "--fs-options does not support --fs-type default. Please use --fs-type ext4 or --fs-type xfs."
+    fi
+
+    if [ -n "$fs_options" ] && [ "$fs_backend" != mkfs ]; then
+        error_and_exit "--fs-options is only supported when root filesystem is formatted directly by trans.sh."
+    fi
 }
 
 get_host_by_url() {
@@ -3116,7 +3258,8 @@ build_extra_cmdline() {
     # https://salsa.debian.org/installer-team/rootskel/-/blob/master/src/lib/debian-installer-startup.d/S02module-params?ref_type=heads
     for key in confhome hold force_boot_mode force_cn force_old_windows_setup cloud_image main_disk \
         elts deb_mirror \
-        ssh_port rdp_port web_port allow_ping; do
+        ssh_port rdp_port web_port allow_ping \
+        fs_type; do
         value=${!key}
         if [ -n "$value" ]; then
             is_need_quote "$value" &&
@@ -3179,6 +3322,9 @@ build_nextos_cmdline() {
         if [ "$nextos_distro" = kali ]; then
             nextos_cmdline+=" net.ifnames=0"
             nextos_cmdline+=" simple-cdd/profiles=kali"
+        fi
+        if [ "$fs_type" = xfs ]; then
+            nextos_cmdline+=" partman/default_filesystem=xfs"
         fi
     elif is_distro_like_redhat $nextos_distro; then
         # redhat
@@ -3320,7 +3466,7 @@ partman-cros
 partman-iscsi
 partman-jfs
 partman-md
-partman-xfs
+$([ "$fs_type" != xfs ] && echo partman-xfs)
 rescue-check
 wpasupplicant-udeb
 lilo-installer
@@ -3337,7 +3483,7 @@ firewire-core-modules-$kver-di
 usb-storage-modules-$kver-di
 isofs-modules-$kver-di
 jfs-modules-$kver-di
-xfs-modules-$kver-di
+$([ "$fs_type" != xfs ] && echo xfs-modules-$kver-di)
 loop-modules-$kver-di
 pata-modules-$kver-di
 sata-modules-$kver-di
@@ -3845,6 +3991,12 @@ This script is outdated, please download reinstall.sh again.
     if [ -n "$frpc_config" ]; then
         cat "$frpc_config" >$initrd_dir/configs/frpc.conf
     fi
+    if [ -n "$fs_type" ]; then
+        printf '%s\n' "$fs_type" >$initrd_dir/configs/fs_type
+    fi
+    if [ -n "$fs_options" ]; then
+        printf '%s\n' "$fs_options" >$initrd_dir/configs/fs_options
+    fi
 
     # 收集 cloud-data 打包进 initrd
     if [ -n "$cloud_data" ]; then
@@ -4304,6 +4456,7 @@ long_opts=
 for o in ci installer debug minimal allow-ping force-cn help \
     add-driver: \
     hold: sleep: \
+    fs-type: fs-options: \
     iso: \
     image-name: \
     boot-wim: \
@@ -4395,6 +4548,23 @@ while true; do
     --minimal)
         minimal=1
         shift
+        ;;
+    --fs-type)
+        [ -n "$2" ] || error_and_exit "Need value for $1"
+        fs_type_set=1
+        fs_type=$(to_lower <<<"$2")
+        if ! { [ "$fs_type" = default ] || [ "$fs_type" = ext4 ] || [ "$fs_type" = xfs ]; }; then
+            error_and_exit "Invalid $1 value: $2"
+        fi
+        shift 2
+        ;;
+    --fs-options)
+        [ -n "$2" ] || error_and_exit "Need value for $1"
+        fs_options=$(sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//' <<<"$2")
+        if ! is_fs_options_valid "$fs_options"; then
+            error_and_exit "Invalid $1 value: $2"
+        fi
+        shift 2
         ;;
     --allow-ping)
         allow_ping=1
@@ -4647,6 +4817,9 @@ redhat | centos | almalinux | rocky | fedora | ubuntu)
     fi
     ;;
 esac
+
+# 文件系统参数依赖最终安装后端（installer/cloud-image/mkfs），需在模式归一化后检查
+verify_fs_args
 
 # 检查内存
 # 会用到 wmic，因此要在设置国内 confhome 后使用

--- a/trans.sh
+++ b/trans.sh
@@ -418,6 +418,16 @@ extract_env_from_cmdline() {
     done
 }
 
+load_fs_config() {
+    if [ -f /configs/fs_type ]; then
+        fs_type=$(head -n1 /configs/fs_type | to_lower)
+    fi
+
+    if [ -f /configs/fs_options ]; then
+        fs_options=$(head -n1 /configs/fs_options)
+    fi
+}
+
 ensure_service_started() {
     local service=$1
 
@@ -2563,6 +2573,45 @@ xda() {
     fi
 }
 
+get_root_fs_type() {
+    if [ -n "$fs_type" ] && [ "$fs_type" != default ]; then
+        echo "$fs_type"
+    else
+        echo ext4
+    fi
+}
+
+format_root_partition() {
+    local part=$1
+    local label=$2
+    local ext4_compat_opts=$3
+    local root_fs
+
+    root_fs=$(get_root_fs_type)
+    info false "format root: $part ($root_fs)"
+
+    # shellcheck disable=SC2086
+    case "$root_fs" in
+    ext4)
+        if [ -n "$label" ]; then
+            mkfs.ext4 -F -L "$label" $fs_options $ext4_compat_opts "$part"
+        else
+            mkfs.ext4 -F $fs_options $ext4_compat_opts "$part"
+        fi
+        ;;
+    xfs)
+        if [ -n "$label" ]; then
+            mkfs.xfs -f -L "$label" $fs_options "$part"
+        else
+            mkfs.xfs -f $fs_options "$part"
+        fi
+        ;;
+    *)
+        error_and_exit "Unsupported root fs type: $root_fs"
+        ;;
+    esac
+}
+
 create_part() {
     # 除了 dd 都会用到
     info "Create Part"
@@ -2571,6 +2620,9 @@ create_part() {
     apk add parted e2fsprogs
     if is_efi; then
         apk add dosfstools
+    fi
+    if [ "$fs_type" = xfs ]; then
+        apk add xfsprogs
     fi
 
     # 清除分区签名
@@ -2687,7 +2739,7 @@ create_part() {
             update_part
 
             mkfs.fat "/dev/$(xda 1)"                #1 efi
-            mkfs.ext4 -F $ext4_opts "/dev/$(xda 2)" #2 os + installer
+            format_root_partition "/dev/$(xda 2)" '' "$ext4_opts" #2 os + installer
         elif is_xda_gt_2t; then
             # bios > 2t
             # 官方安装器是 mkpart BOOT 1M 100M，无论 esp 或者 bios_grub 都用这个分区和大小
@@ -2699,7 +2751,7 @@ create_part() {
             update_part
 
             echo                                    #1 bios_boot
-            mkfs.ext4 -F $ext4_opts "/dev/$(xda 2)" #2 os + installer
+            format_root_partition "/dev/$(xda 2)" '' "$ext4_opts" #2 os + installer
         else
             # bios
             parted /dev/$xda -s -- \
@@ -2710,7 +2762,7 @@ create_part() {
             update_part
 
             echo                                    #1 官方安装有这个分区
-            mkfs.ext4 -F $ext4_opts "/dev/$(xda 2)" #2 os + installer
+            format_root_partition "/dev/$(xda 2)" '' "$ext4_opts" #2 os + installer
         fi
     elif is_use_cloud_image; then
         installer_part_size="$(get_cloud_image_part_size)"
@@ -2720,7 +2772,7 @@ create_part() {
             [ "$distro" = anolis ] || [ "$distro" = opencloudos ] || [ "$distro" = openeuler ] ||
             [ "$distro" = ubuntu ]; then
             # 这里的 fs 没有用，最终使用目标系统的格式化工具
-            fs=ext4
+            fs=$(get_root_fs_type)
             if is_efi; then
                 parted /dev/$xda -s -- \
                     mklabel gpt \
@@ -2760,6 +2812,7 @@ create_part() {
         fi
     elif [ "$distro" = alpine ] || [ "$distro" = arch ] || [ "$distro" = gentoo ] ||
         [ "$distro" = nixos ] || [ "$distro" = aosc ]; then
+        root_fs=$(get_root_fs_type)
         # alpine 本身关闭了 64bit ext4
         # https://gitlab.alpinelinux.org/alpine/alpine-conf/-/blob/3.18.1/setup-disk.in?ref_type=tags#L908
         # 而且 alpine 的 extlinux 不兼容 64bit ext4
@@ -2769,32 +2822,32 @@ create_part() {
             parted /dev/$xda -s -- \
                 mklabel gpt \
                 mkpart '" "' fat32 1MiB 101MiB \
-                mkpart '" "' ext4 101MiB 100% \
+                mkpart '" "' $root_fs 101MiB 100% \
                 set 1 boot on
             update_part
 
             mkfs.fat "/dev/$(xda 1)"                #1 efi
-            mkfs.ext4 -F $ext4_opts "/dev/$(xda 2)" #2 os
+            format_root_partition "/dev/$(xda 2)" '' "$ext4_opts" #2 os
         elif is_xda_gt_2t; then
             # bios > 2t
             parted /dev/$xda -s -- \
                 mklabel gpt \
                 mkpart '" "' ext4 1MiB 2MiB \
-                mkpart '" "' ext4 2MiB 100% \
+                mkpart '" "' $root_fs 2MiB 100% \
                 set 1 bios_grub on
             update_part
 
             echo                                    #1 bios_boot
-            mkfs.ext4 -F $ext4_opts "/dev/$(xda 2)" #2 os
+            format_root_partition "/dev/$(xda 2)" '' "$ext4_opts" #2 os
         else
             # bios
             parted /dev/$xda -s -- \
                 mklabel msdos \
-                mkpart primary ext4 1MiB 100% \
+                mkpart primary $root_fs 1MiB 100% \
                 set 1 boot on
             update_part
 
-            mkfs.ext4 -F $ext4_opts "/dev/$(xda 1)" #1 os
+            format_root_partition "/dev/$(xda 1)" '' "$ext4_opts" #1 os
         fi
     else
         # 安装红帽系或ubuntu
@@ -4702,11 +4755,15 @@ install_qcow_by_copy() {
         # mapper/vg_main-lv_root
         # mapper/opencloudos-root
 
+        # 修正根分区的格式和 uuid (可能原镜像为 lvm / ext4 / xfs / 甚至是 LABEL 挂载)
+        os_fs_uuid=$(lsblk -rno UUID "/dev/$(xda 2)")
+        sed -i -E "s|^[^#[:space:]]+([[:space:]]+/[[:space:]]+)[^[:space:]]+([[:space:]]+)[^[:space:]]+|UUID=$os_fs_uuid\1$target_os_fstype\2defaults|" /os/etc/fstab
+
         # oracle/opencloudos 系统盘从 lvm 改成 uuid 挂载
-        sed -i "s,/dev/$os_part,UUID=$os_part_uuid," /os/etc/fstab
+        sed -i "s,/dev/$os_part,UUID=$os_fs_uuid," /os/etc/fstab
         if ls /os/boot/loader/entries/*.conf 2>/dev/null; then
             # options root=/dev/mapper/opencloudos-root ro console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=1800M-64G:256M,64G-128G:512M,128G-486G:768M,486G-972G:1024M,972G-:2048M rd.lvm.lv=opencloudos/root rhgb quiet
-            sed -i "s,/dev/$os_part,UUID=$os_part_uuid," /os/boot/loader/entries/*.conf
+            sed -i "s,/dev/$os_part,UUID=$os_fs_uuid," /os/boot/loader/entries/*.conf
         fi
 
         # oracle/opencloudos 移除 lvm cmdline
@@ -5050,6 +5107,17 @@ EOF
             fi
         fi
 
+        # fstab
+        # 修正根分区的格式和 uuid (原镜像可能是 ext4 或者是 LABEL 挂载)
+        os_fs_uuid=$(lsblk -rno UUID "/dev/$(xda 2)")
+        sed -i -E "s|^[^#[:space:]]+([[:space:]]+/[[:space:]]+)[^[:space:]]+([[:space:]]+)[^[:space:]]+|UUID=$os_fs_uuid\1$target_os_fstype\2defaults|" $os_dir/etc/fstab
+        # 24.04 镜像有boot分区，但我们不需要
+        sed -i '/[[:space:]]\/boot[[:space:]]/d' $os_dir/etc/fstab
+        if ! is_efi; then
+            # bios 删除 efi 条目
+            sed -i '/[[:space:]]\/boot\/efi[[:space:]]/d' $os_dir/etc/fstab
+        fi
+
         # 要重新生成 grub.cfg，因为
         # 1 我们删除了 boot 分区
         # 2 改动了 /etc/default/grub.d/40-force-partuuid.cfg
@@ -5057,14 +5125,6 @@ EOF
 
         # 还原 grub 配置（os prober）
         mv $os_dir/etc/default/grub.orig $os_dir/etc/default/grub
-
-        # fstab
-        # 24.04 镜像有boot分区，但我们不需要
-        sed -i '/[[:space:]]\/boot[[:space:]]/d' $os_dir/etc/fstab
-        if ! is_efi; then
-            # bios 删除 efi 条目
-            sed -i '/[[:space:]]\/boot\/efi[[:space:]]/d' $os_dir/etc/fstab
-        fi
 
         restore_resolv_conf $os_dir
     }
@@ -5192,9 +5252,33 @@ EOF
     # centos8 如果用alpine格式化xfs，grub2-mkconfig和grub2里面都无法识别xfs分区
     mount_nouuid /dev/$os_part /nbd/
     mount_pseudo_fs /nbd/
-    case "$os_part_fstype" in
-    ext4) chroot /nbd mkfs.ext4 -F -L "$os_part_label" -U "$os_part_uuid" "/dev/$(xda 2)" ;;
-    xfs) chroot /nbd mkfs.xfs -f -L "$os_part_label" -m uuid=$os_part_uuid "/dev/$(xda 2)" ;;
+    if [ -n "$fs_type" ] && [ "$fs_type" != default ]; then
+        target_os_fstype=$fs_type
+    else
+        target_os_fstype=$os_part_fstype
+    fi
+    # shellcheck disable=SC2086
+    case "$target_os_fstype" in
+    ext4)
+        chroot /nbd mkfs.ext4 -F ${os_part_label:+-L "$os_part_label"} $fs_options -U "$os_part_uuid" "/dev/$(xda 2)"
+        ;;
+    xfs)
+        # Ensure xfsprogs is installed in target image for mkfs.xfs
+        if ! chroot /nbd test -x /sbin/mkfs.xfs 2>/dev/null; then
+            info "Installing xfsprogs in target image..."
+            chroot /nbd apt-get update >/dev/null 2>&1 || true
+            chroot /nbd apt-get install -y xfsprogs 2>&1 | grep -E '(Setting up|E:)' || true
+            if ! chroot /nbd test -x /sbin/mkfs.xfs; then
+                error_and_exit "Failed to install xfsprogs in target image. xfs not available."
+            fi
+        fi
+        # XFS limit label to 12 chars
+        mkfs_label="${os_part_label:0:12}"
+        chroot /nbd mkfs.xfs -f ${mkfs_label:+-L "$mkfs_label"} $fs_options -m uuid=$os_part_uuid "/dev/$(xda 2)"
+        ;;
+    *)
+        error_and_exit "Unsupported target root fs type: $target_os_fstype"
+        ;;
     esac
     umount -R /nbd/
 
@@ -7720,6 +7804,7 @@ rm -f /etc/runlevels/default/local
 
 # 提取变量
 extract_env_from_cmdline
+load_fs_config
 
 # 带参数运行部分
 # 重新下载并 exec 运行新脚本

--- a/ubuntu-storage-early.sh
+++ b/ubuntu-storage-early.sh
@@ -14,6 +14,11 @@ size_os=$(lsblk -bn -o SIZE /dev/disk/by-label/os)
 
 # shellcheck disable=SC2154
 if parted "/dev/$xda" print | grep '^Partition Table' | grep gpt; then
+  case "$fs_type" in
+  ext4 | xfs) root_fstype=$fs_type ;;
+  *) root_fstype=ext4 ;;
+  esac
+
     # efi
     if [ -e /dev/disk/by-label/efi ]; then
         size_efi=$(lsblk -bn -o SIZE /dev/disk/by-label/efi)
@@ -44,7 +49,7 @@ if parted "/dev/$xda" print | grep '^Partition Table' | grep gpt; then
       preserve: true
       type: partition
       id: partition-os
-    - fstype: ext4
+    - fstype: $root_fstype
       volume: partition-os
       type: format
       id: format-os
@@ -84,7 +89,7 @@ EOF
       preserve: true
       type: partition
       id: partition-os
-    - fstype: ext4
+    - fstype: $root_fstype
       volume: partition-os
       type: format
       id: format-os
@@ -97,6 +102,11 @@ EOF
     fi
 else
     # bios
+  case "$fs_type" in
+  ext4 | xfs) root_fstype=$fs_type ;;
+  *) root_fstype=ext4 ;;
+  esac
+
     cat <<EOF >>/autoinstall.yaml
   config:
     # disk
@@ -113,7 +123,7 @@ else
       preserve: true
       type: partition
       id: partition-os
-    - fstype: ext4
+    - fstype: $root_fstype
       volume: partition-os
       type: format
       id: format-os

--- a/ubuntu.yaml
+++ b/ubuntu.yaml
@@ -27,7 +27,7 @@ autoinstall:
 
       # 生成分区信息
       xda=$(curl -L "$confhome/get-xda.sh" | sh -s)
-      export xda
+      export xda fs_type
       curl -L "$confhome/ubuntu-storage-early.sh" | sh -s
 
       # 要安装的版本


### PR DESCRIPTION
## 概述

这个 PR 为 Linux 重装流程加入了指定根分区的文件系统和参数的功能; 增加两个可选参数来指定目标根文件系统类型, 并为根分区传入可选的 mkfs 参数, 前提要求是使用的安装方法直接操作根分区 mkfs

## 变更内容

- 新增 `--fs-type default|ext4|xfs`, 用于指定目标根分区文件系统
- 新增 `--fs-options`, 用于向根分区的 mkfs 追加参数, 仅当 `--fs-type` 非 `default` 时才能使用
- 参数检查:
  - `default` 为脚本现有逻辑; 目前显式支持 `ext4` 和 `xfs`; 更多类型将在以后逐渐加入
  - 由于 XFS v4 已被弃用并将在 2030 年被移出内核, 因此脚本强制要求 XFS v5 格式, 对应需要最低 Linux 5.10 内核, 脚本将拒绝内核默认版本不达标的发行版版本
  - `--fs-options` 只允许在真正由 `trans.sh` 直接格式化根分区的安装方法上使用
  - Debian `--ci` 好像实际是基于镜像的, 因此不支持指定文件系统和参数
  - 飞牛OS目前尚不确定是否支持 XFS 会导致问题, 因此暂不支持指定文件系统和参数
- 更新了安装器、云镜像复制和 fstab 重写相关逻辑, 使选定的FS类型/参数可以贯穿到实际格式化过程
- 同步更新了中英文 README

## 支持情况

| 发行版 | 可用安装方法 | `--fs-type`  | `--fs-options`  |
|---|---|---|---|
| Debian / Kali | Debian installer 或 cloud-image `--ci` | Debian installer: 支持, XFS 要求 Debian 11+ 或 Kali <br> cloud-image: 否 | 否 |
| Ubuntu | cloud-image 或 ISO installer | 支持, XFS 要求 22.04+ | cloud-image: 支持; ISO installer: 否 |
| RHEL 家族 | cloud-image 或 ISO installer | 支持, XFS 要求 9+ | cloud-image: 支持; ISO installer: 否 |
| Anolis | cloud-image | 支持, XFS 要求 8/23+ | 支持 |
| OpenCloudOS | cloud-image | 支持, XFS 要求 9/23+ | 支持 |
| openEuler | cloud-image 或 installer | 支持, XFS 要求 22.03+ | cloud-image: 支持; installer: 否 |
| openSUSE | installer 或 cloud-image / dd image  | installer: 支持; cloud/dd image: 否 | 否 |
| Alpine / Arch / Gentoo / AOSC / NixOS | 仅直接 mkfs | 支持 | 支持 |
| fnOS | 仅直接 mkfs | 否 | 否 |

## 验证

- 通过 `bash -n reinstall.sh`
- 通过 `bash -n trans.sh`
- 通过 `bash -n ubuntu-storage-early.sh`
- 在真实 VPS 上测试通过