### PR TITLE
windows: preload bios grub modules

### DIFF
--- a/trans.sh
+++ b/trans.sh
@@ -7956,6 +7956,8 @@ EOF
         cat <<EOF >"$(get_path_in_correct_case /os/boot/grub/grub.cfg)"
             set timeout=5
             menuentry "reinstall" {
+                insmod search
+                insmod ntldr
                 search --no-floppy --label --set=root os
                 ntldr /$(cd /os && get_path_in_correct_case bootmgr)
             }


### PR DESCRIPTION
## Summary
- Explicitly preload `search` and `ntldr` in the BIOS Windows GRUB menuentry.
- Avoid relying on GRUB command autoload when chainloading Windows `bootmgr`.

## Context
Fixes #633.

## Test plan
- `bash -n trans.sh`
- Verified branch diff is limited to two inserted lines in `trans.sh`.