### PR TITLE
fix: 修复部分 VPS 安装 x86/x64 Windows 时 virtio 驱动获取失败

### DIFF
--- a/trans.sh
+++ b/trans.sh
@@ -7334,6 +7334,51 @@ EOF
 
         local baseurl=https://fedorapeople.org/groups/virt/virtio-win/direct-downloads
 
+        add_driver_virtio_from_rpm() {
+            # fedorapeople may reject or timeout on some VPS IPs, and DaoCloud may still fetch from it.
+            # The CentOS Stream x86_64 repo publishes this noarch RPM with Windows x86/x64 virtio drivers.
+            local url=https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/Packages/virtio-win-1.9.45-1.el10.noarch.rpm
+            local cpio_file
+
+            info "Add drivers: Generic virtio rpm"
+            apk add 7zip
+
+            download "$url" $drv/virtio.rpm
+
+            mkdir -p $drv/virtio-rpm/stage $drv/virtio-rpm/root
+            7z x $drv/virtio.rpm -o$drv/virtio-rpm/stage -y -bb1
+            cpio_file=$(find $drv/virtio-rpm/stage -maxdepth 1 -name '*.cpio' | head -1)
+            [ -n "$cpio_file" ] || error_and_exit "Failed to extract virtio-win rpm."
+            7z x "$cpio_file" -o$drv/virtio-rpm/root -y -bb1 \
+                -i'!./usr/share/virtio-win/drivers/by-driver/*/'"$virtio_sys"'/'"$arch"'/*'
+            find $drv/virtio-rpm/root -type f -ipath "*/$virtio_sys/$arch/*.inf" "$@" | grep . >/dev/null ||
+                error_and_exit "Can't find $virtio_sys/$arch drivers in virtio-win rpm."
+            cp_drivers $drv/virtio-rpm/root "$@"
+        }
+
+        get_latest_virtio_dir() {
+            local checksum=$1/stable-virtio/CHECKSUM
+            local dir
+
+            # 直接读取 CHECKSUM 可以兼容 fedorapeople 跳转和提供文件内容的镜像源
+            if dir=$(wget "$checksum" -O- |
+                grep -Eo -m1 'virtio-win-[0-9][^[:space:]]+\.noarch\.rpm' |
+                sed -E 's,^virtio-win-(.*)\.noarch\.rpm$,archive-virtio/virtio-win-\1,' |
+                grep .); then
+                echo "$dir"
+                return
+            fi
+
+            # 保留 Location 解析作为兼容逻辑
+            if dir=$(wget --spider -S "$checksum" 2>&1 >/dev/null |
+                grep -E '^  Location: ' | grep -Ewo -m1 'archive-virtio/virtio-win-[^/]+'); then
+                echo "$dir"
+                return
+            fi
+
+            return 1
+        }
+
         case "$nt_ver" in
         6.0 | 6.1) $support_sha256 &&
             dir=archive-virtio/virtio-win-0.1.187-1 ||
@@ -7348,8 +7393,17 @@ EOF
 
             # https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/CHECKSUM
             # 路径是文件，应该不会弹出 anubis 验证？
-            dir=$(wget --spider -S "$baseurl/stable-virtio/CHECKSUM" 2>&1 >/dev/null |
-                grep -E '^  Location: ' | grep -Ewo -m1 'archive-virtio/virtio-win-[^/]+')
+            if ! dir=$(get_latest_virtio_dir "$baseurl"); then
+                mirror_baseurl=https://files.m.daocloud.io/$(echo "$baseurl" | sed -E 's,^https?://,,i')
+                if is_any_ipv4_has_internet && dir=$(get_latest_virtio_dir "$mirror_baseurl"); then
+                    baseurl=$mirror_baseurl
+                elif [ "$arch_wim" = x86 ] || [ "$arch_wim" = x86_64 ]; then
+                    add_driver_virtio_from_rpm "$@"
+                    return
+                else
+                    error_and_exit "Failed to get latest virtio-win version."
+                fi
+            fi
             # dir=stable-virtio
             ;;
         esac


### PR DESCRIPTION
TLDR: 遇到一个比较小众的问题，fedorapeople.org反bot防火墙比较高，有台香港的VPS装windows时无法访问fedorapeople.org下载virtio，导致安装失败；然后发现走 DaoCloud 也不行；最后只好加了一个 CentOS 的源做兜底。

## 问题

部分 VPS IP 访问 `fedorapeople.org` 会超时或被拒绝，导致 Windows 安装流程在获取最新 `virtio-win` 版本时失败。

DaoCloud 对该 URL 也可能回源访问 `fedorapeople.org`，因此不能完全覆盖该场景。

## 修改

generic virtio 驱动获取现在按以下顺序兜底：

1. 直接读取 `fedorapeople.org` 的 `stable-virtio/CHECKSUM`
2. 失败后尝试 DaoCloud 镜像
3. 如果仍失败，则对 x86/x64 Windows 使用 CentOS Stream x86_64 仓库中的 `virtio-win` noarch RPM

通用 `download()` 行为保持不变，避免影响其他下载路径。

## 说明

CentOS Stream 的仓库路径是 `x86_64`，但该 `virtio-win` 包本身是 `noarch.rpm`，包内包含 Windows x86/x64 virtio 驱动目录。

RPM 兜底仅用于 x86/x64 Windows，不用于 arm64。

## 修改前 vs 修改后

修改前
```log
<之前省略>
***** MOUNT BOOT.WIM *****
***** ADD DRIVERS *****
(1/2) Installing dmidecode (3.7-r0)
(2/2) Installing virt-what (1.27-r1)
Executing busybox-1.37.0-r31.trigger
OK: 50.6 MiB in 117 packages
(1/2) Purging virt-what (1.27-r1)
(2/2) Purging dmidecode (3.7-r0)
Executing busybox-1.37.0-r31.trigger
OK: 50.4 MiB in 115 packages
OK: 50.4 MiB in 115 packages
***** ADD DRIVERS: GENERIC VIRTIO *****
***** ERROR *****
Line 7339 return 1
                grep -E '^  Location: ' | grep -Ewo -m1 'archive-virtio/virtio-win-[^/]+')
localhost:~$ Run 'sudo /trans.sh' to retry.
Run 'sudo /trans.sh alpine' to install Alpine Linux instead.
```

修改后
```log
<之前省略>
***** MOUNT BOOT.WIM *****
***** ADD DRIVERS *****
(1/2) Installing dmidecode (3.7-r0)
(2/2) Installing virt-what (1.27-r1)
Executing busybox-1.37.0-r31.trigger
OK: 52.2 MiB in 120 packages
(1/2) Purging virt-what (1.27-r1)
(2/2) Purging dmidecode (3.7-r0)
Executing busybox-1.37.0-r31.trigger
OK: 52.0 MiB in 118 packages
OK: 52.0 MiB in 118 packages
***** ADD DRIVERS: GENERIC VIRTIO *****
https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/CHECKSUM
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
https://files.m.daocloud.io/fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/CHECKSUM
Connecting to files.m.daocloud.io (8.217.45.147:443)
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to files.m.daocloud.io (8.217.45.147:443)
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to files.m.daocloud.io (8.217.45.147:443)
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to files.m.daocloud.io (8.217.45.147:443)
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
Connecting to files.m.daocloud.io (8.217.45.147:443)
Connecting to fedorapeople.org (152.2.23.109:443)
wget: download timed out
***** ADD DRIVERS: GENERIC VIRTIO RPM *****
(1/1) Installing 7zip (26.01-r0)
Executing busybox-1.37.0-r31.trigger
OK: 53.7 MiB in 119 packages
https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/Packages/virtio-win-1.9.45-1.el10.noarch.rpm

06/26 16:11:08 [NOTICE] Downloading 1 item(s)
[#ea49d6 32KiB/258MiB(0%) CN:4 DL:94KiB ETA:46m24s]
[#ea49d6 4.5MiB/258MiB(1%) CN:4 DL:3.2MiB ETA:1m17s]
[#ea49d6 10MiB/258MiB(4%) CN:4 DL:4.4MiB ETA:56s]
[#ea49d6 16MiB/258MiB(6%) CN:4 DL:4.9MiB ETA:48s]
<中间省略>
[#ea49d6 245MiB/258MiB(95%) CN:4 DL:5.8MiB ETA:2s]
[#ea49d6 251MiB/258MiB(97%) CN:2 DL:5.8MiB ETA:1s]
[#ea49d6 257MiB/258MiB(99%) CN:1 DL:5.8MiB]

06/26 16:11:53 [NOTICE] Download complete: /os/drivers/virtio.rpm

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
ea49d6|OK  |   5.8MiB/s|/os/drivers/virtio.rpm

Status Legend:
(OK):download completed.

7-Zip (z) 26.01 (x64) : Copyright (c) 1999-2026 Igor Pavlov : 2026-04-27
 64-bit locale=C.UTF-8 Threads:8 OPEN_MAX:4096

Scanning the drive for archives:
1 file, 270586309 bytes (259 MiB)

Extracting archive: /os/drivers/virtio.rpm
--
Path = /os/drivers/virtio.rpm
Type = Rpm
Physical Size = 270586309
Headers Size = 858505
CPU = noarch
Host OS = linux
Created = 2025-02-25 01:34:18
----
Path = virtio-win-1.9.45-1.el10.noarch.cpio.zst
Size = 269727804
Created = 2025-02-25 01:34:18
--
Path = virtio-win-1.9.45-1.el10.noarch.cpio.zst
Type = zstd
Method = header-open-only: NO-XXH64 wnd-desc-log-MAX:23 wnd-MAX:8MiB unknown-content-size

- virtio-win-1.9.45-1.el10.noarch.cpio
Everything is Ok

Size:       1112527948
Compressed: 270586309

7-Zip (z) 26.01 (x64) : Copyright (c) 1999-2026 Igor Pavlov : 2026-04-27
 64-bit locale=C.UTF-8 Threads:8 OPEN_MAX:4096

Scanning the drive for archives:
1 file, 1112527948 bytes (1061 MiB)

Extracting archive: /os/drivers/virtio-rpm/stage/virtio-win-1.9.45-1.el10.noarch.cpio
--
Path = /os/drivers/virtio-rpm/stage/virtio-win-1.9.45-1.el10.noarch.cpio
Type = Cpio
Physical Size = 1112527948
SubType = New ASCII

- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/Readme.md
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvm.cat
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvm.inf
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvm.sys
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvmp.exe
- ./usr/share/virtio-win/drivers/by-driver/vioscsi/w10/amd64/vioscsi.cat
- ./usr/share/virtio-win/drivers/by-driver/vioscsi/w10/amd64/vioscsi.inf
- ./usr/share/virtio-win/drivers/by-driver/vioscsi/w10/amd64/vioscsi.sys
- ./usr/share/virtio-win/drivers/by-driver/viostor/w10/amd64/viostor.cat
- ./usr/share/virtio-win/drivers/by-driver/viostor/w10/amd64/viostor.inf
- ./usr/share/virtio-win/drivers/by-driver/viostor/w10/amd64/viostor.sys
- ./usr/share/virtio-win/drivers/by-driver/Balloon/w10/amd64/balloon.inf
- ./usr/share/virtio-win/drivers/by-driver/Balloon/w10/amd64/balloon.pdb
- ./usr/share/virtio-win/drivers/by-driver/Balloon/w10/amd64/blnsvr.exe
- ./usr/share/virtio-win/drivers/by-driver/Balloon/w10/amd64/blnsvr.pdb
- ./usr/share/virtio-win/drivers/by-driver/Balloon/w10/amd64/balloon.cat
- ./usr/share/virtio-win/drivers/by-driver/Balloon/w10/amd64/balloon.sys
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvm.pdb
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvmco.pdb
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvmp.pdb
- ./usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvmco.exe
- ./usr/share/virtio-win/drivers/by-driver/fwcfg/w10/amd64/fwcfg.inf
- ./usr/share/virtio-win/drivers/by-driver/fwcfg/w10/amd64/fwcfg.pdb
- ./usr/share/virtio-win/drivers/by-driver/fwcfg/w10/amd64/fwcfg.cat
- ./usr/share/virtio-win/drivers/by-driver/fwcfg/w10/amd64/fwcfg.sys
- ./usr/share/virtio-win/drivers/by-driver/pvpanic/w10/amd64/pvpanic.inf
- ./usr/share/virtio-win/drivers/by-driver/pvpanic/w10/amd64/pvpanic.pdb
- ./usr/share/virtio-win/drivers/by-driver/pvpanic/w10/amd64/pvpanic.cat
- ./usr/share/virtio-win/drivers/by-driver/pvpanic/w10/amd64/pvpanic.sys
- ./usr/share/virtio-win/drivers/by-driver/qemufwcfg/w10/amd64/qemufwcfg.cat
- ./usr/share/virtio-win/drivers/by-driver/qemufwcfg/w10/amd64/qemufwcfg.inf
- ./usr/share/virtio-win/drivers/by-driver/qemupciserial/w10/amd64/qemupciserial.inf
- ./usr/share/virtio-win/drivers/by-driver/qemupciserial/w10/amd64/qemupciserial.cat
- ./usr/share/virtio-win/drivers/by-driver/qxldod/w10/amd64/qxldod.cat
- ./usr/share/virtio-win/drivers/by-driver/qxldod/w10/amd64/qxldod.inf
- ./usr/share/virtio-win/drivers/by-driver/qxldod/w10/amd64/qxldod.sys
- ./usr/share/virtio-win/drivers/by-driver/sriov/w10/amd64/vioprot.inf
- ./usr/share/virtio-win/drivers/by-driver/sriov/w10/amd64/vioprot.cat
- ./usr/share/virtio-win/drivers/by-driver/viofs/w10/amd64/viofs.inf
- ./usr/share/virtio-win/drivers/by-driver/viofs/w10/amd64/viofs.pdb
- ./usr/share/virtio-win/drivers/by-driver/viofs/w10/amd64/virtiofs.exe
- ./usr/share/virtio-win/drivers/by-driver/viofs/w10/amd64/virtiofs.pdb
- ./usr/share/virtio-win/drivers/by-driver/viofs/w10/amd64/viofs.cat
- ./usr/share/virtio-win/drivers/by-driver/viofs/w10/amd64/viofs.sys
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/vgpusrv.exe
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/vgpusrv.pdb
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/viogpuap.exe
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/viogpuap.pdb
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/viogpudo.inf
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/viogpudo.pdb
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/viogpudo.cat
- ./usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/viogpudo.sys
- ./usr/share/virtio-win/drivers/by-driver/vioinput/w10/amd64/viohidkmdf.pdb
- ./usr/share/virtio-win/drivers/by-driver/vioinput/w10/amd64/vioinput.inf
- ./usr/share/virtio-win/drivers/by-driver/vioinput/w10/amd64/vioinput.pdb
- ./usr/share/virtio-win/drivers/by-driver/vioinput/w10/amd64/viohidkmdf.sys
- ./usr/share/virtio-win/drivers/by-driver/vioinput/w10/amd64/vioinput.cat
- ./usr/share/virtio-win/drivers/by-driver/vioinput/w10/amd64/vioinput.sys
- ./usr/share/virtio-win/drivers/by-driver/viomem/w10/amd64/viomem.inf
- ./usr/share/virtio-win/drivers/by-driver/viomem/w10/amd64/viomem.pdb
- ./usr/share/virtio-win/drivers/by-driver/viomem/w10/amd64/viomem.cat
- ./usr/share/virtio-win/drivers/by-driver/viomem/w10/amd64/viomem.sys
- ./usr/share/virtio-win/drivers/by-driver/viorng/w10/amd64/viorng.inf
- ./usr/share/virtio-win/drivers/by-driver/viorng/w10/amd64/viorng.pdb
- ./usr/share/virtio-win/drivers/by-driver/viorng/w10/amd64/viorngum.pdb
- ./usr/share/virtio-win/drivers/by-driver/viorng/w10/amd64/viorng.cat
- ./usr/share/virtio-win/drivers/by-driver/viorng/w10/amd64/viorng.sys
- ./usr/share/virtio-win/drivers/by-driver/viorng/w10/amd64/viorngum.dll
- ./usr/share/virtio-win/drivers/by-driver/vioscsi/w10/amd64/vioscsi.pdb
- ./usr/share/virtio-win/drivers/by-driver/vioserial/w10/amd64/vioser.inf
- ./usr/share/virtio-win/drivers/by-driver/vioserial/w10/amd64/vioser.pdb
- ./usr/share/virtio-win/drivers/by-driver/vioserial/w10/amd64/vioser.cat
- ./usr/share/virtio-win/drivers/by-driver/vioserial/w10/amd64/vioser.sys
- ./usr/share/virtio-win/drivers/by-driver/viostor/w10/amd64/viostor.pdb
Everything is Ok

Files: 74
Size:       55342424
Compressed: 1112527948
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/Balloon/w10/amd64/balloon.inf *****
'balloon.inf' -> '/wim/drivers/1/balloon.inf'
'balloon.cat' -> '/wim/drivers/1/balloon.cat'
'balloon.sys' -> '/wim/drivers/1/balloon.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/fwcfg/w10/amd64/fwcfg.inf *****
'fwcfg.inf' -> '/wim/drivers/2/fwcfg.inf'
'fwcfg.cat' -> '/wim/drivers/2/fwcfg.cat'
'fwcfg.sys' -> '/wim/drivers/2/fwcfg.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/NetKVM/w10/amd64/netkvm.inf *****
'netkvm.inf' -> '/wim/drivers/3/netkvm.inf'
'netkvm.cat' -> '/wim/drivers/3/netkvm.cat'
'netkvm.sys' -> '/wim/drivers/3/netkvm.sys'
'netkvmp.exe' -> '/wim/drivers/3/netkvmp.exe'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/pvpanic/w10/amd64/pvpanic.inf *****
'pvpanic.inf' -> '/wim/drivers/4/pvpanic.inf'
'pvpanic.cat' -> '/wim/drivers/4/pvpanic.cat'
'pvpanic.sys' -> '/wim/drivers/4/pvpanic.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/qemufwcfg/w10/amd64/qemufwcfg.inf *****
'qemufwcfg.inf' -> '/wim/drivers/5/qemufwcfg.inf'
'qemufwcfg.cat' -> '/wim/drivers/5/qemufwcfg.cat'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/qemupciserial/w10/amd64/qemupciserial.inf *****
'qemupciserial.inf' -> '/wim/drivers/6/qemupciserial.inf'
'qemupciserial.cat' -> '/wim/drivers/6/qemupciserial.cat'
Warning: Can't find serial.sys
Warning: Can't find serenum.sys
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/qxldod/w10/amd64/qxldod.inf *****
'qxldod.inf' -> '/wim/drivers/7/qxldod.inf'
'qxldod.cat' -> '/wim/drivers/7/qxldod.cat'
'qxldod.sys' -> '/wim/drivers/7/qxldod.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/sriov/w10/amd64/vioprot.inf *****
'vioprot.inf' -> '/wim/drivers/8/vioprot.inf'
'vioprot.cat' -> '/wim/drivers/8/vioprot.cat'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/viofs/w10/amd64/viofs.inf *****
'viofs.inf' -> '/wim/drivers/9/viofs.inf'
'viofs.cat' -> '/wim/drivers/9/viofs.cat'
'viofs.sys' -> '/wim/drivers/9/viofs.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/viogpudo/w10/amd64/viogpudo.inf *****
'viogpudo.inf' -> '/wim/drivers/10/viogpudo.inf'
'viogpudo.cat' -> '/wim/drivers/10/viogpudo.cat'
'viogpudo.sys' -> '/wim/drivers/10/viogpudo.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/vioinput/w10/amd64/vioinput.inf *****
'vioinput.inf' -> '/wim/drivers/11/vioinput.inf'
'vioinput.cat' -> '/wim/drivers/11/vioinput.cat'
'vioinput.sys' -> '/wim/drivers/11/vioinput.sys'
'viohidkmdf.sys' -> '/wim/drivers/11/viohidkmdf.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/viomem/w10/amd64/viomem.inf *****
'viomem.inf' -> '/wim/drivers/12/viomem.inf'
'viomem.cat' -> '/wim/drivers/12/viomem.cat'
'viomem.sys' -> '/wim/drivers/12/viomem.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/viorng/w10/amd64/viorng.inf *****
'viorng.inf' -> '/wim/drivers/13/viorng.inf'
'viorng.cat' -> '/wim/drivers/13/viorng.cat'
'viorng.sys' -> '/wim/drivers/13/viorng.sys'
'viorngum.dll' -> '/wim/drivers/13/viorngum.dll'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/vioscsi/w10/amd64/vioscsi.inf *****
'vioscsi.inf' -> '/wim/drivers/14/vioscsi.inf'
'vioscsi.cat' -> '/wim/drivers/14/vioscsi.cat'
'vioscsi.sys' -> '/wim/drivers/14/vioscsi.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/vioserial/w10/amd64/vioser.inf *****
'vioser.inf' -> '/wim/drivers/15/vioser.inf'
'vioser.cat' -> '/wim/drivers/15/vioser.cat'
'vioser.sys' -> '/wim/drivers/15/vioser.sys'
***** Add driver: /os/drivers/virtio-rpm/root/usr/share/virtio-win/drivers/by-driver/viostor/w10/amd64/viostor.inf *****
'viostor.inf' -> '/wim/drivers/16/viostor.inf'
'viostor.cat' -> '/wim/drivers/16/viostor.cat'
'viostor.sys' -> '/wim/drivers/16/viostor.sys'
***** AUTOUNATTEND.XML *****
     1  <?xml version="1.0" encoding="utf-8"?>
     2  <unattend xmlns="urn:schemas-microsoft-com:unattend">
     3    <settings pass="windowsPE">
     4      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
     5        <EnableFirewall>false</EnableFirewall>
     6        <UserData>
     7          <AcceptEula>true</AcceptEula>
     8          <ProductKey>
     9          </ProductKey>
    10        </UserData>
    11        <ImageInstall>
    12          <OSImage>
    13            <InstallFrom>
    14              <MetaData wcm:action="add">
    15                <Key>/IMAGE/NAME</Key>
    16                <Value>Windows 10 Pro</Value>
    17              </MetaData>
    18            </InstallFrom>
    19            <InstallTo>
    20              <DiskID>%disk_id%</DiskID>
    21              <PartitionID>1</PartitionID>
    22            </InstallTo>
    23          </OSImage>
    24        </ImageInstall>
    25      </component>
    26      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    27        <InputLocale>en-US</InputLocale>
    28        <SystemLocale>en-US</SystemLocale>
    29        <UILanguage>en-US</UILanguage>
    30        <UserLocale>en-US</UserLocale>
    31      </component>
    32    </settings>
    33    <settings pass="offlineServicing">
    34      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    35        <DriverPaths>
    36          <PathAndCredentials wcm:action="add" wcm:keyValue="1">
    37            <Path>X:\drivers</Path>
    38          </PathAndCredentials>
    39          <PathAndCredentials wcm:action="add" wcm:keyValue="2">
    40            <Path>X:\custom_drivers</Path>
    41          </PathAndCredentials>
    42        </DriverPaths>
    43      </component>
    44    </settings>
    45    <settings pass="specialize">
    46      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    47        <RunSynchronous>
    48          <RunSynchronousCommand wcm:action="add">
    49            <Order>1</Order>
    50            <Path>powercfg /setacvalueindex SCHEME_BALANCED SUB_VIDEO VIDEOIDLE 0</Path>
    51          </RunSynchronousCommand>
    52          <RunSynchronousCommand wcm:action="add">
    53            <Order>2</Order>
    54            <Path>powercfg /setacvalueindex SCHEME_MIN SUB_VIDEO VIDEOIDLE 0</Path>
    55          </RunSynchronousCommand>
    56          <RunSynchronousCommand wcm:action="add">
    57            <Order>3</Order>
    58            <Path>powercfg /setacvalueindex SCHEME_MAX SUB_VIDEO VIDEOIDLE 0</Path>
    59          </RunSynchronousCommand>
    60          <RunSynchronousCommand wcm:action="add">
    61            <Order>4</Order>
    62            <Path>powercfg /setactive SCHEME_MIN</Path>
    63          </RunSynchronousCommand>
    64          <RunSynchronousCommand wcm:action="add">
    65            <Order>5</Order>
    66            <Path>cmd /c "if "0"=="1" for %a in (Administrator Administrador Administrateur Administratör Администратор Järjestelmänvalvoja Rendszergazda) do (net user %a /active:yes &amp;&amp; exit)"</Path>
    67          </RunSynchronousCommand>
    68          <RunSynchronousCommand wcm:action="add">
    69            <Order>6</Order>
    70            <Path>reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager /v ShippedWithReserves /t REG_DWORD /d 0 /f</Path>
    71          </RunSynchronousCommand>
    72        </RunSynchronous>
    73      </component>
    74      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    75        <fDenyTSConnections>false</fDenyTSConnections>
    76      </component>
    77      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    78        <FirewallGroups>
    79          <FirewallGroup wcm:action="add" wcm:keyValue="RemoteDesktop">
    80            <Profile>all</Profile>
    81            <Group>@FirewallAPI.dll,-28752</Group>
    82            <Active>true</Active>
    83          </FirewallGroup>
    84        </FirewallGroups>
    85      </component>
    86      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-powercpl" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    87        <PreferredPlan>8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c</PreferredPlan>
    88      </component>
    89      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-ErrorReportingCore" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    90        <DisableWER>1</DisableWER>
    91      </component>
    92      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-SQMApi" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    93        <CEIPEnabled>0</CEIPEnabled>
    94      </component>
    95    </settings>
    96    <settings pass="oobeSystem">
    97      <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
    98        <UserAccounts>
    99          <LocalAccounts>
   100            <LocalAccount wcm:action="add">
   101              <Name>root</Name>
   102              <Group>Administrators</Group>
   103            </LocalAccount>
   104          </LocalAccounts>
   105        </UserAccounts>
   106        <OOBE>
   107          <HideEULAPage>true</HideEULAPage>
   108          <SkipMachineOOBE>true</SkipMachineOOBE>
   109          <SkipUserOOBE>true</SkipUserOOBE>
   110        </OOBE>
   111      </component>
   112    </settings>
   113  </unattend>
(1/4) Purging xmlstarlet (1.6.1-r2)
(2/4) Purging libxslt (1.1.43-r3)
(3/4) Purging libxml2 (2.13.9-r2)
(4/4) Purging xz-libs (5.8.3-r0)
Executing busybox-1.37.0-r31.trigger
OK: 52.1 MiB in 115 packages
https://raw.githubusercontent.com/bin456789/reinstall/main/windows-setup.bat

06/26 16:11:57 [NOTICE] Downloading 1 item(s)

06/26 16:11:57 [NOTICE] Download complete: /wim/Windows/System32/startnet.cmd

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
bd0aef|OK  |   4.8MiB/s|/wim/Windows/System32/startnet.cmd

Status Legend:
(OK):download completed.
***** UNMOUNT BOOT.WIM *****
Committing changes to /os/boot.wim (image 2)
Using LZX compression with 1 thread
Archiving file data: 1573 KiB of 1573 KiB (100%) done
Using LZX compression with 8 threads
Archiving file data: 1191 MiB of 1191 MiB (100%) done
***** BOOT.WIM SIZE *****
Original:      544
Added Drivers: 546
Optimized:     532
<之后省略>
```

