### PR TITLE
fix: avoid misplaced ifupdown IPv6 options

### DIFF
--- a/trans.sh
+++ b/trans.sh
@@ -1250,9 +1250,10 @@ EOF
         fi
 
         # ipv6
+        has_ipv6_iface=false
         if is_slaac; then
             echo "iface $ethx inet6 auto" >>$conf_file
-
+            has_ipv6_iface=true
         elif is_dhcpv6; then
             # debian 13 使用 ifupdown + dhcpcd-base
             # inet/inet6 都配置成 dhcp 时，重启后 dhcpv4 会丢失
@@ -1264,7 +1265,7 @@ EOF
             else
                 echo "iface $ethx inet6 dhcp" >>$conf_file
             fi
-
+            has_ipv6_iface=true
         elif is_staticv6; then
             get_netconf_to ipv6_addr
             get_netconf_to ipv6_gateway
@@ -1273,6 +1274,7 @@ iface $ethx inet6 static
     address $ipv6_addr
     gateway $ipv6_gateway
 EOF
+            has_ipv6_iface=true
             # debian 9
             # ipv4 支持静态 onlink 网关
             # ipv6 不支持静态 onlink 网关，需使用 post-up 添加，未测试动态
@@ -1300,7 +1302,14 @@ EOF
                 )
             fi
         fi
-
+        # accept_ra/autoconf 属于 iface 选项
+        # 如果当前网卡没有生成 IPv6 iface stanza，
+        # 先补一个 manual stanza，避免 ifupdown 报 misplaced option
+        if ! $has_ipv6_iface &&
+            { should_disable_accept_ra || should_disable_autoconf; } &&
+            [ "$distro" != alpine ]; then
+            echo "iface $ethx inet6 manual" >>$conf_file
+        fi
         # dns
         # 有 ipv6 但需设置 dns 的情况
         if is_need_manual_set_dnsv6; then


### PR DESCRIPTION
在部分多网卡场景下，`trans.sh` 生成 Debian/Ubuntu 的

`/etc/network/interfaces` 时，可能会生成不符合 ifupdown 语法的 IPv6 配置。

例如机器存在两张网卡：

- `ens3`：没有配置 IPv4/IPv6 地址，但需要关闭 IPv6 RA / autoconf

- `ens4`：通过 DHCP 获取 IPv4 地址

当前逻辑可能生成类似下面的配置：

```text

auto ens3

    accept_ra 0

    autoconf 0

auto ens4

iface ens4 inet dhcp
```

此时 accept_ra 和 autoconf 前面没有对应的 iface stanza。

ifupdown 会将其识别为 misplaced option，导致 /etc/network/interfaces
解析失败，进一步可能造成 networking.service 启动失败。

修改方案

增加 has_ipv6_iface 状态，用于记录当前网卡是否已经生成 IPv6 iface stanza。

以下情况会将其设置为 true：

* SLAAC
* DHCPv6
* Static IPv6

如果：

1. 当前网卡没有生成任何 IPv6 iface stanza；
2. 但仍然需要设置 accept_ra 或 autoconf；
3. 当前系统不是 Alpine；